### PR TITLE
fix webgl-preview.ts

### DIFF
--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -283,7 +283,7 @@ export class WebGLPreview {
           // update state
           if (next.x) state.x = next.x;
           if (next.y) state.y = next.y;
-          if (next.z) state.z = next.z;
+          if (next.z >= 0) state.z = next.z;
           // if (next.e) state.e = next.e; // where not really tracking e as distance (yet) but we only check if some commands are extruding (positive e)
           if (!this.beyondFirstMove) this.beyondFirstMove = true;
         }


### PR DESCRIPTION
When  paramater z is 0 in some commands the preview shows this

<img src="https://github.com/remcoder/gcode-preview/assets/76708845/10fc35f6-d9a4-4530-a087-08cebc2e28dd" width="300">

to fix this change from :
> `if (next.z)`
to
> `if (next.z >= 0)`

Then it shows as it should



<img src="https://github.com/remcoder/gcode-preview/assets/76708845/11234e8d-df0b-4764-ad16-223af9c72048" width="300">
