### PR TITLE
fix webgl-preview.ts

### DIFF
--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -268,7 +268,7 @@ export class WebGLPreview {
 
           if (index >= this.minLayerIndex) {
             const extrude = g.params.e > 0 || this.nonTravelmoves.indexOf(cmd.gcode) > -1;
-            const moving = next.x != state.x || next.y != state.y;
+            const moving = next.x != state.x || next.y != state.y || next.z != state.z;
             if (moving) {
               if ((extrude && this.renderExtrusion) || (!extrude && this.renderTravel)) {
                 if (cmd.gcode == 'g2' || cmd.gcode == 'g3' || cmd.gcode == 'g02' || cmd.gcode == 'g03') {


### PR DESCRIPTION
in this short gcode the travel line not shows

> G0 X0 Y0 Z0
>G1 X0 Y0 Z10 E0

<img src="https://github.com/remcoder/gcode-preview/assets/76708845/740b5115-8308-464f-a416-19fb84dcc093" with="300" />

to show line of travel completely vertical add this
`|| next.z != state.z`

<img src="https://github.com/remcoder/gcode-preview/assets/76708845/2f52e014-c767-4a1c-8c52-d7e68330a453" with="300" />



