### PR TITLE
Fix slowdown in progressive render

### DIFF
--- a/demo/js/demo.js
+++ b/demo/js/demo.js
@@ -151,7 +151,6 @@ const settingsPresets = {
 export function initDemo() {
   // eslint-disable-line no-unused-vars, @typescript-eslint/no-unused-vars
   const settings = JSON.parse(localStorage.getItem('settings'));
-  console.debug('settings loaded', settings);
 
   const initialBackgroundColor = preferDarkMode.matches ? '#111' : '#eee';
 
@@ -406,7 +405,6 @@ export function initDemo() {
   function changeHighlightTopLayer(enabled) {
     toggleHighlight.checked = enabled;
     if (enabled) {
-      console.log('topLayerColorInput.value', topLayerColorInput.value);
       changeTopLayerColor(preview.topLayerColor || '#40BFBF');
       changeLastSegmentColor(preview.lastSegmentColor || '#ffffff');
       topLayerColorInput.removeAttribute('disabled');
@@ -559,9 +557,7 @@ async function startLoadingProgressive(gcode) {
   gcodePreview.clear();
   gcodePreview.parser.parseGCode(gcode);
   updateUI();
-  console.time('render');
   await gcodePreview.renderAnimated(Math.ceil(gcodePreview.layers.length / 60));
-  console.timeEnd('render');
   updateUI();
   startLayer.removeAttribute('disabled');
   endLayer.removeAttribute('disabled');

--- a/demo/js/demo.js
+++ b/demo/js/demo.js
@@ -313,17 +313,18 @@ export function initDemo() {
     fileName.innerText = file.name;
     fileSize.innerText = humanFileSize(file.size);
 
-    preview.clear();
+    // preview.clear();
     if (preview.renderTubes && file.size > FILE_SIZE_10MB) {
       confirm('This file is large and may take a while to render in this mode. Change to line rendering?')
         ? (preview.renderTubes = false)
         : (preview.renderTubes = true);
     }
     preview.initScene();
-    await preview._readFromStream(file.stream());
+    preview.clear();
+    // await preview._readFromStream(file.stream());
+    _handleGCode(file.name, await file.text());
     updateUI();
     currentFile = file;
-    preview.render();
   });
 
   function updateBuildVolume() {
@@ -540,17 +541,17 @@ function updateUI() {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
-async function loadGCodeFromServer(file) {
-  const response = await fetch(file);
-  currentFile = file;
+async function loadGCodeFromServer(filename) {
+  const response = await fetch(filename);
+  currentFile = filename;
   if (response.status !== 200) {
     console.error('ERROR. Status Code: ' + response.status);
     return;
   }
 
   const gcode = await response.text();
-  _handleGCode(file, gcode);
-  fileName.setAttribute('href', file);
+  _handleGCode(filename, gcode);
+  fileName.setAttribute('href', filename);
 }
 
 function _handleGCode(filename, gcode) {
@@ -580,8 +581,7 @@ function startLoadingProgressive(gcode) {
       endLayer.removeAttribute('disabled');
     }
     gcodePreview.parser.parseGCode(chunk);
-    if (gcodePreview.renderTubes) gcodePreview.renderIncremental();
-    else gcodePreview.render();
+    gcodePreview.renderIncremental();
     updateUI();
   }
 

--- a/demo/js/demo.js
+++ b/demo/js/demo.js
@@ -55,7 +55,7 @@ const settingsPresets = {
     lineWidth: 1,
     singleLayerMode: false,
     renderExtrusion: true,
-    renderTubes: false,
+    renderTubes: true,
     extrusionColors: ['#CF439D', 'rgb(84,74,187)', 'white', 'rgb(83,209,104)'],
     travel: false,
     travelColor: '#00FF00',

--- a/demo/js/demo.js
+++ b/demo/js/demo.js
@@ -560,35 +560,20 @@ function _handleGCode(filename, text) {
   startLoadingProgressive(text);
 }
 
-function startLoadingProgressive(gcode) {
-  let c = 0;
+async function startLoadingProgressive(gcode) {
   startLayer.setAttribute('disabled', 'disabled');
   endLayer.setAttribute('disabled', 'disabled');
 
-  function loadProgressive() {
-    const start = c * chunkSize;
-    const end = (c + 1) * chunkSize;
-    const chunk = lines.slice(start, end);
-
-    c++;
-    if (c < chunks) {
-      window.__loadTimer__ = requestAnimationFrame(loadProgressive);
-    } else {
-      startLayer.removeAttribute('disabled');
-      endLayer.removeAttribute('disabled');
-    }
-
-    gcodePreview.parser.parseGCode(chunk);
-    gcodePreview.renderInc();
-    updateUI();
-  }
-
-  const lines = gcode.split('\n');
-  const chunks = lines.length / chunkSize;
   gcodePreview.initScene();
   gcodePreview.clear();
-  if (window.__loadTimer__) clearTimeout(window.__loadTimer__);
-  loadProgressive();
+  gcodePreview.parser.parseGCode(gcode);
+  updateUI();
+  console.time('render');
+  await gcodePreview.renderAnimated(Math.round(gcodePreview.layers.length / 60));
+  console.timeEnd('render');
+  updateUI();
+  startLayer.removeAttribute('disabled');
+  endLayer.removeAttribute('disabled');
 }
 
 function humanFileSize(size) {

--- a/demo/js/demo.js
+++ b/demo/js/demo.js
@@ -550,7 +550,6 @@ async function loadGCodeFromServer(filename) {
 
 function _handleGCode(filename, text) {
   gcode = text;
-  chunkSize = text.length / 1000;
   fileName.innerText = filename;
   fileSize.innerText = humanFileSize(text.length);
 
@@ -568,7 +567,7 @@ async function startLoadingProgressive(gcode) {
   gcodePreview.parser.parseGCode(gcode);
   updateUI();
   console.time('render');
-  await gcodePreview.renderAnimated(Math.round(gcodePreview.layers.length / 60));
+  await gcodePreview.renderAnimated(Math.ceil(gcodePreview.layers.length / 60));
   console.timeEnd('render');
   updateUI();
   startLayer.removeAttribute('disabled');

--- a/demo/js/demo.js
+++ b/demo/js/demo.js
@@ -564,6 +564,7 @@ function startLoadingProgressive(gcode) {
   let c = 0;
   startLayer.setAttribute('disabled', 'disabled');
   endLayer.setAttribute('disabled', 'disabled');
+
   function loadProgressive() {
     const start = c * chunkSize;
     const end = (c + 1) * chunkSize;
@@ -576,6 +577,7 @@ function startLoadingProgressive(gcode) {
       startLayer.removeAttribute('disabled');
       endLayer.removeAttribute('disabled');
     }
+
     gcodePreview.parser.parseGCode(chunk);
     gcodePreview.renderInc();
     updateUI();
@@ -583,6 +585,7 @@ function startLoadingProgressive(gcode) {
 
   const lines = gcode.split('\n');
   const chunks = lines.length / chunkSize;
+  gcodePreview.initScene();
   gcodePreview.clear();
   if (window.__loadTimer__) clearTimeout(window.__loadTimer__);
   loadProgressive();

--- a/demo/js/demo.js
+++ b/demo/js/demo.js
@@ -55,7 +55,7 @@ const settingsPresets = {
     lineWidth: 1,
     singleLayerMode: false,
     renderExtrusion: true,
-    renderTubes: true,
+    renderTubes: false,
     extrusionColors: ['#CF439D', 'rgb(84,74,187)', 'white', 'rgb(83,209,104)'],
     travel: false,
     travelColor: '#00FF00',

--- a/demo/js/demo.js
+++ b/demo/js/demo.js
@@ -9,7 +9,7 @@ const maxToolCount = 8;
 let toolCount = 4;
 let chunkSize = 1000;
 let currentFile;
-const FILE_SIZE_5MB = 5 * 1024 * 1024;
+const FILE_SIZE_10MB = 10 * 1024 * 1024;
 
 const canvasElement = document.querySelector('.gcode-previewer');
 const settingsPreset = document.getElementById('settings-presets');
@@ -218,7 +218,7 @@ export function initDemo() {
 
   toggleRenderTubes.addEventListener('click', function () {
     changeRenderTubes(!!toggleRenderTubes.checked);
-    if (preview.renderTubes && currentFile.size > FILE_SIZE_5MB) {
+    if (preview.renderTubes && currentFile.size > FILE_SIZE_10MB) {
       confirm('This file is large and may take a while to render in this mode. Continue?')
         ? (preview.renderTubes = true)
         : (preview.renderTubes = false);
@@ -314,7 +314,7 @@ export function initDemo() {
     fileSize.innerText = humanFileSize(file.size);
 
     preview.clear();
-    if (preview.renderTubes && file.size > FILE_SIZE_5MB) {
+    if (preview.renderTubes && file.size > FILE_SIZE_10MB) {
       confirm('This file is large and may take a while to render in this mode. Change to line rendering?')
         ? (preview.renderTubes = false)
         : (preview.renderTubes = true);

--- a/demo/js/demo.js
+++ b/demo/js/demo.js
@@ -5,9 +5,11 @@ import * as Canvas2Image from 'canvas2image';
 let gcodePreview;
 let favIcon;
 let thumb;
-let chunkSize = 10000;
 const maxToolCount = 8;
 let toolCount = 4;
+let chunkSize = 1000;
+let currentFile;
+const FILE_SIZE_5MB = 5 * 1024 * 1024;
 
 const canvasElement = document.querySelector('.gcode-previewer');
 const settingsPreset = document.getElementById('settings-presets');
@@ -216,6 +218,12 @@ export function initDemo() {
 
   toggleRenderTubes.addEventListener('click', function () {
     changeRenderTubes(!!toggleRenderTubes.checked);
+    if (preview.renderTubes && currentFile.size > FILE_SIZE_5MB) {
+      confirm('This file is large and may take a while to render in this mode. Continue?')
+        ? (preview.renderTubes = true)
+        : (preview.renderTubes = false);
+      toggleRenderTubes.checked = preview.renderTubes;
+    }
     preview.render();
   });
 
@@ -306,7 +314,7 @@ export function initDemo() {
     fileSize.innerText = humanFileSize(file.size);
 
     preview.clear();
-    if (preview.renderTubes && file.size > 5 * 1024 * 1024) {
+    if (preview.renderTubes && file.size > FILE_SIZE_5MB) {
       confirm('This file is large and may take a while to render in this mode. Change to line rendering?')
         ? (preview.renderTubes = false)
         : (preview.renderTubes = true);
@@ -314,6 +322,7 @@ export function initDemo() {
     preview.initScene();
     await preview._readFromStream(file.stream());
     updateUI();
+    currentFile = file;
     preview.render();
   });
 
@@ -533,7 +542,7 @@ function updateUI() {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
 async function loadGCodeFromServer(file) {
   const response = await fetch(file);
-
+  currentFile = file;
   if (response.status !== 200) {
     console.error('ERROR. Status Code: ' + response.status);
     return;

--- a/demo/js/demo.js
+++ b/demo/js/demo.js
@@ -8,7 +8,6 @@ let thumb;
 const maxToolCount = 8;
 let toolCount = 4;
 let gcode;
-const FILE_SIZE_10MB = 10 * 1024 * 1024;
 
 const canvasElement = document.querySelector('.gcode-previewer');
 const settingsPreset = document.getElementById('settings-presets');
@@ -309,12 +308,6 @@ export function initDemo() {
     fileName.innerText = file.name;
     fileSize.innerText = humanFileSize(file.size);
 
-    // preview.clear();
-    if (preview.renderTubes && file.size > FILE_SIZE_10MB) {
-      confirm('This file is large and may take a while to render in this mode. Change to line rendering?')
-        ? (preview.renderTubes = false)
-        : (preview.renderTubes = true);
-    }
     preview.initScene();
     preview.clear();
     // await preview._readFromStream(file.stream());

--- a/demo/js/demo.js
+++ b/demo/js/demo.js
@@ -8,6 +8,7 @@ let thumb;
 const maxToolCount = 8;
 let toolCount = 4;
 let gcode;
+let renderProgressive = true;
 
 const canvasElement = document.querySelector('.gcode-previewer');
 const settingsPreset = document.getElementById('settings-presets');
@@ -44,7 +45,6 @@ const buildVolumeY = document.getElementById('buildVolumeY');
 const buildVolumeZ = document.getElementById('buildVolumeZ');
 const drawBuildVolume = document.getElementById('drawBuildVolume');
 const travelColor = document.getElementById('travel-color');
-
 const preferDarkMode = window.matchMedia('(prefers-color-scheme: dark)');
 
 const defaultPreset = 'multicolor';
@@ -215,10 +215,7 @@ export function initDemo() {
 
   toggleRenderTubes.addEventListener('click', function () {
     changeRenderTubes(!!toggleRenderTubes.checked);
-    preview.initScene();
     startLoadingProgressive(gcode);
-    // preview.clear();
-    // preview.renderInc();
   });
 
   for (let i = 0; i < 8; i++) {
@@ -307,8 +304,6 @@ export function initDemo() {
     fileName.innerText = file.name;
     fileSize.innerText = humanFileSize(file.size);
 
-    preview.initScene();
-    preview.clear();
     // await preview._readFromStream(file.stream());
     _handleGCode(file.name, await file.text());
     updateUI();
@@ -553,12 +548,16 @@ async function startLoadingProgressive(gcode) {
   startLayer.setAttribute('disabled', 'disabled');
   endLayer.setAttribute('disabled', 'disabled');
 
-  gcodePreview.initScene();
   gcodePreview.clear();
-  gcodePreview.parser.parseGCode(gcode);
+  if (renderProgressive) {
+    gcodePreview.parser.parseGCode(gcode);
+    updateUI();
+    await gcodePreview.renderAnimated(Math.ceil(gcodePreview.layers.length / 60));
+  } else {
+    gcodePreview.processGCode(gcode);
+  }
   updateUI();
-  await gcodePreview.renderAnimated(Math.ceil(gcodePreview.layers.length / 60));
-  updateUI();
+
   startLayer.removeAttribute('disabled');
   endLayer.removeAttribute('disabled');
 }

--- a/demo/js/demo.js
+++ b/demo/js/demo.js
@@ -8,7 +8,7 @@ let thumb;
 const maxToolCount = 8;
 let toolCount = 4;
 let chunkSize = 1000;
-let currentFileSize;
+let gcode;
 const FILE_SIZE_10MB = 10 * 1024 * 1024;
 
 const canvasElement = document.querySelector('.gcode-previewer');
@@ -218,7 +218,10 @@ export function initDemo() {
 
   toggleRenderTubes.addEventListener('click', function () {
     changeRenderTubes(!!toggleRenderTubes.checked);
-    preview.renderIncremental();
+    preview.initScene();
+    startLoadingProgressive(gcode);
+    // preview.clear();
+    // preview.renderInc();
   });
 
   for (let i = 0; i < 8; i++) {
@@ -318,7 +321,6 @@ export function initDemo() {
     // await preview._readFromStream(file.stream());
     _handleGCode(file.name, await file.text());
     updateUI();
-    currentFileSize = file.size;
   });
 
   function updateBuildVolume() {
@@ -543,19 +545,19 @@ async function loadGCodeFromServer(filename) {
   }
 
   const gcode = await response.text();
-  currentFileSize = gcode.length;
   _handleGCode(filename, gcode);
   fileName.setAttribute('href', filename);
 }
 
-function _handleGCode(filename, gcode) {
-  chunkSize = gcode.length / 1000;
+function _handleGCode(filename, text) {
+  gcode = text;
+  chunkSize = text.length / 1000;
   fileName.innerText = filename;
-  fileSize.innerText = humanFileSize(gcode.length);
+  fileSize.innerText = humanFileSize(text.length);
 
   updateUI();
 
-  startLoadingProgressive(gcode);
+  startLoadingProgressive(text);
 }
 
 function startLoadingProgressive(gcode) {
@@ -575,7 +577,7 @@ function startLoadingProgressive(gcode) {
       endLayer.removeAttribute('disabled');
     }
     gcodePreview.parser.parseGCode(chunk);
-    gcodePreview.renderIncremental();
+    gcodePreview.renderInc();
     updateUI();
   }
 

--- a/demo/js/demo.js
+++ b/demo/js/demo.js
@@ -7,7 +7,6 @@ let favIcon;
 let thumb;
 const maxToolCount = 8;
 let toolCount = 4;
-let chunkSize = 1000;
 let gcode;
 const FILE_SIZE_10MB = 10 * 1024 * 1024;
 

--- a/demo/js/demo.js
+++ b/demo/js/demo.js
@@ -8,7 +8,7 @@ let thumb;
 const maxToolCount = 8;
 let toolCount = 4;
 let chunkSize = 1000;
-let currentFile;
+let currentFileSize;
 const FILE_SIZE_10MB = 10 * 1024 * 1024;
 
 const canvasElement = document.querySelector('.gcode-previewer');
@@ -218,13 +218,7 @@ export function initDemo() {
 
   toggleRenderTubes.addEventListener('click', function () {
     changeRenderTubes(!!toggleRenderTubes.checked);
-    if (preview.renderTubes && currentFile.size > FILE_SIZE_10MB) {
-      confirm('This file is large and may take a while to render in this mode. Continue?')
-        ? (preview.renderTubes = true)
-        : (preview.renderTubes = false);
-      toggleRenderTubes.checked = preview.renderTubes;
-    }
-    preview.render();
+    preview.renderIncremental();
   });
 
   for (let i = 0; i < 8; i++) {
@@ -324,7 +318,7 @@ export function initDemo() {
     // await preview._readFromStream(file.stream());
     _handleGCode(file.name, await file.text());
     updateUI();
-    currentFile = file;
+    currentFileSize = file.size;
   });
 
   function updateBuildVolume() {
@@ -543,13 +537,13 @@ function updateUI() {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
 async function loadGCodeFromServer(filename) {
   const response = await fetch(filename);
-  currentFile = filename;
   if (response.status !== 200) {
     console.error('ERROR. Status Code: ' + response.status);
     return;
   }
 
   const gcode = await response.text();
+  currentFileSize = gcode.length;
   _handleGCode(filename, gcode);
   fileName.setAttribute('href', filename);
 }

--- a/src/__tests__/webgl-preview.ts
+++ b/src/__tests__/webgl-preview.ts
@@ -87,7 +87,6 @@ test('cancelAnimation should cancel the render loop', async () => {
 function createMockPreview() {
   return {
     state: { x: 0, y: 0, z: 0, r: 0, e: 0, i: 0, j: 0 },
-
     minLayerIndex: 0,
     maxLayerIndex: Infinity,
     disposables: [

--- a/src/__tests__/webgl-preview.ts
+++ b/src/__tests__/webgl-preview.ts
@@ -2,7 +2,7 @@
 
 import { test, expect, vi, assert } from 'vitest';
 
-import { WebGLPreview } from '../webgl-preview';
+import { State, WebGLPreview } from '../webgl-preview';
 import { GCodeCommand } from '../gcode-parser';
 
 test('in gcode x,y,z params should update the state', () => {
@@ -86,7 +86,7 @@ test('cancelAnimation should cancel the render loop', async () => {
 
 function createMockPreview() {
   return {
-    state: { x: 0, y: 0, z: 0, r: 0, e: 0, i: 0, j: 0 },
+    state: State.initial,
     minLayerIndex: 0,
     maxLayerIndex: Infinity,
     disposables: [

--- a/src/gcode-parser.ts
+++ b/src/gcode-parser.ts
@@ -147,7 +147,7 @@ export class Parser {
   }
 
   private lines2commands(lines: string[]) {
-    return lines.map((l) => this.parseCommand(l)).filter((cmd) => cmd != null) as GCodeCommand[];
+    return lines.map((l) => this.parseCommand(l)) as GCodeCommand[];
   }
 
   parseCommand(line: string, keepComments = true): GCodeCommand | null {

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -130,8 +130,6 @@ export class WebGLPreview {
 
   // gcode processing state
   private state: State = State.initial;
-  private prevState: State;
-  private prevLayerIndex?: number = undefined;
   private beyondFirstMove = false;
 
   // rendering
@@ -427,9 +425,7 @@ export class WebGLPreview {
     this.group = this.createGroup('layer' + this.renderLayerIndex);
 
     for (let l = 0; l < layerCount && this.renderLayerIndex + l < this.layers.length; l++) {
-      this.state = this.prevState ?? State.initial;
       this.renderLayer(this.renderLayerIndex);
-      this.prevState = { ...this.state };
       this.renderLayerIndex++;
     }
 
@@ -576,8 +572,6 @@ export class WebGLPreview {
     this.state = State.initial;
     this.devGui?.reset();
     this._geometries = {};
-    this.prevState = undefined;
-    this.prevLayerIndex = undefined;
   }
 
   resize(): void {

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -395,6 +395,8 @@ export class WebGLPreview {
   // create a new render method to use an animation loop to render the layers incrementally
   /** @experimental */
   async renderAnimated(layerCount = 1): Promise<void> {
+    this.initScene();
+
     this.renderLayerIndex = 0;
     return this.renderFrameLoop(layerCount > 0 ? layerCount : 1);
   }
@@ -560,6 +562,7 @@ export class WebGLPreview {
     this.startLayer = 1;
     this.endLayer = Infinity;
     this.singleLayerMode = false;
+
     this.beyondFirstMove = false;
     this.state = State.initial;
     this.devGui?.reset();

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -561,7 +561,7 @@ export class WebGLPreview {
     this.singleLayerMode = false;
     this.parser = new Parser(this.minLayerThreshold);
     this.beyondFirstMove = false;
-    this.state = { x: 0, y: 0, z: 0, r: 0, e: 0, i: 0, j: 0, t: 0 };
+    this.state = State.initial;
     this.devGui?.reset();
     this._geometries = {};
   }
@@ -803,6 +803,7 @@ export class WebGLPreview {
     let tail = '';
     let size = 0;
     do {
+      console.debug('reading from stream');
       result = await reader.read();
       size += result.value?.length ?? 0;
       const str = decode(result.value);

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -393,6 +393,7 @@ export class WebGLPreview {
   }
 
   // create a new render method to use an animation loop to render the layers incrementally
+  /** @experimental */
   async renderAnimated(layerCount = 1): Promise<void> {
     this.renderLayerIndex = 0;
     return this.renderFrameLoop(layerCount > 0 ? layerCount : 1);

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -433,7 +433,7 @@ export class WebGLPreview {
   // create a new render method to use an animation loop to render the layers incrementally
   async renderAnimated(layerCount = 1): Promise<void> {
     this.renderLayerIndex = 0;
-    return this.renderFrameLoop(layerCount);
+    return this.renderFrameLoop(layerCount > 0 ? layerCount : 1);
   }
 
   renderFrameLoop(layerCount: number): Promise<void> {

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -225,6 +225,7 @@ export class WebGLPreview {
     this.resize();
 
     this.controls = new OrbitControls(this.camera, this.renderer.domElement);
+    this.initScene();
     this.animate();
 
     if (this.allowDragNDrop) this._enableDropHandler();
@@ -318,8 +319,7 @@ export class WebGLPreview {
     this.render();
   }
 
-  render(): void {
-    const startRender = performance.now();
+  initScene() {
     while (this.scene.children.length > 0) {
       this.scene.remove(this.scene.children[0]);
     }
@@ -348,36 +348,37 @@ export class WebGLPreview {
       this.scene.add(light);
       this.scene.add(dLight);
     }
+  }
 
-    this.group = new Group();
-    this.group.name = 'gcode';
-
+  render(): void {
+    const startRender = performance.now();
     for (let index = 0; index < this.layers.length; index++) {
+      this.group = new Group();
+      this.group.name = 'layer' + index;
       this.renderLayer(index);
-    }
+      this.group.quaternion.setFromEuler(new Euler(-Math.PI / 2, 0, 0));
 
-    this.group.quaternion.setFromEuler(new Euler(-Math.PI / 2, 0, 0));
+      if (this.buildVolume) {
+        this.group.position.set(-this.buildVolume.x / 2, 0, this.buildVolume.y / 2);
+      } else {
+        // FIXME: this is just a very crude approximation for centering
+        this.group.position.set(-100, 0, 100);
+      }
 
-    if (this.buildVolume) {
-      this.group.position.set(-this.buildVolume.x / 2, 0, this.buildVolume.y / 2);
-    } else {
-      // FIXME: this is just a very crude approximation for centering
-      this.group.position.set(-100, 0, 100);
-    }
-
-    if (this._geometries) {
-      for (const color in this._geometries) {
-        const mesh = this.createBatchMesh(parseInt(color));
-        while (this._geometries[color].length > 0) {
-          const geometry = this._geometries[color].pop();
-          mesh.addGeometry(geometry);
+      if (this._geometries) {
+        for (const color in this._geometries) {
+          const mesh = this.createBatchMesh(parseInt(color));
+          while (this._geometries[color].length > 0) {
+            const geometry = this._geometries[color].pop();
+            mesh.addGeometry(geometry);
+          }
         }
       }
-    }
 
-    this.scene.add(this.group);
-    this.renderer.render(this.scene, this.camera);
-    this._lastRenderTime = performance.now() - startRender;
+      this.scene.add(this.group);
+      this.renderer.render(this.scene, this.camera);
+      this._lastRenderTime = performance.now() - startRender;
+    }
   }
 
   renderLayer(index: number): void {

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -43,7 +43,7 @@ type Arc = GVector3 & { r: number; i: number; j: number };
 
 type Point = GVector3;
 type BuildVolume = GVector3;
-export type State = {
+export class State {
   x: number;
   y: number;
   z: number;
@@ -52,7 +52,13 @@ export type State = {
   i: number;
   j: number;
   t: number; // tool index
-}; // feedrate?
+  // feedrate?
+  static get initial(): State {
+    const state = new State();
+    Object.assign(state, { x: 0, y: 0, z: 0, r: 0, e: 0, i: 0, j: 0, t: 0 });
+    return state;
+  }
+}
 
 export type GCodePreviewOptions = {
   buildVolume?: BuildVolume;
@@ -126,7 +132,7 @@ export class WebGLPreview {
   disableGradient = false;
   private devMode?: boolean | DevModeOptions = true;
 
-  private state: State = { x: 0, y: 0, z: 0, r: 0, e: 0, i: 0, j: 0, t: 0 };
+  private state: State = State.initial;
 
   static readonly defaultExtrusionColor = new Color('hotpink');
 
@@ -369,7 +375,7 @@ export class WebGLPreview {
   renderNext(): void {
     // console.log('removing layer', this.prevLayerIndex);
     this.scene.remove(this.group);
-    this.state = this.prevState;
+    this.state = this.prevState ?? State.initial;
 
     for (let index = this.prevLayerIndex ?? 0; index < this.layers.length; index++) {
       this.group = this.createGroup('layer' + index);
@@ -390,7 +396,7 @@ export class WebGLPreview {
     const startRender = performance.now();
     this.group = new Group();
     this.group.name = 'gcode';
-    this.state = { x: 0, y: 0, z: 0, r: 0, e: 0, i: 0, j: 0, t: 0 };
+    this.state = State.initial;
     this.initScene();
 
     while (this.disposables.length > 0) {

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -374,14 +374,14 @@ export class WebGLPreview {
     return group;
   }
 
-  renderIncremental(): void {
-    // console.log('removing layer', this.prevLayerIndex);
-    this.scene.remove(this.group);
+  // Render the next increment. This is done by removing the previous layer and rendering all layers up to the current one.
+  // This way it preserves the state of the previous layers but it does render the top layer again b/c it probably wasnt completed before.
+  renderInc(): void {
+    if (this.group) this.scene.remove(this.group);
     this.state = this.prevState ?? State.initial;
 
     for (let index = this.prevLayerIndex ?? 0; index < this.layers.length; index++) {
       this.group = this.createGroup('layer' + index);
-      // console.log('rendering layer', index);
 
       this.prevState = { ...this.state };
       this.renderLayer(index);
@@ -552,16 +552,23 @@ export class WebGLPreview {
     this.scene.add(geometryBox);
   }
 
+  // reset parser & processing state
   clear(): void {
+    this.resetState();
+    this.parser = new Parser(this.minLayerThreshold);
+  }
+
+  // reset processing state
+  resetState(): void {
     this.startLayer = 1;
     this.endLayer = Infinity;
     this.singleLayerMode = false;
-    this.parser = new Parser(this.minLayerThreshold);
     this.beyondFirstMove = false;
     this.state = State.initial;
     this.devGui?.reset();
     this._geometries = {};
     this.prevState = undefined;
+    this.prevLayerIndex = undefined;
   }
 
   resize(): void {

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -333,7 +333,7 @@ export class WebGLPreview {
     this.render();
   }
 
-  initScene() {
+  private initScene() {
     while (this.scene.children.length > 0) {
       this.scene.remove(this.scene.children[0]);
     }
@@ -364,7 +364,7 @@ export class WebGLPreview {
     }
   }
 
-  createGroup(name: string): Group {
+  private createGroup(name: string): Group {
     const group = new Group();
     group.name = name;
     group.quaternion.setFromEuler(new Euler(-Math.PI / 2, 0, 0));
@@ -375,26 +375,6 @@ export class WebGLPreview {
       group.position.set(-100, 0, 100);
     }
     return group;
-  }
-
-  // Render the next increment. This is done by removing the previous layer and rendering all layers up to the current one.
-  // This way it preserves the state of the previous layers but it does render the top layer again b/c it probably wasnt completed before.
-  renderInc(): void {
-    if (this.group) this.scene.remove(this.group);
-    this.state = this.prevState ?? State.initial;
-
-    for (let index = this.prevLayerIndex ?? 0; index < this.layers.length; index++) {
-      this.group = this.createGroup('layer' + index);
-
-      this.prevState = { ...this.state };
-      this.renderLayer(index);
-
-      this.scene.add(this.group);
-    }
-
-    this.renderer.render(this.scene, this.camera);
-
-    this.prevLayerIndex = this.layers.length - 1;
   }
 
   render(): void {
@@ -429,7 +409,7 @@ export class WebGLPreview {
     return this.renderFrameLoop(layerCount > 0 ? layerCount : 1);
   }
 
-  renderFrameLoop(layerCount: number): Promise<void> {
+  private renderFrameLoop(layerCount: number): Promise<void> {
     return new Promise((resolve) => {
       const loop = () => {
         if (this.renderLayerIndex > this.layers.length - 1) {
@@ -443,7 +423,7 @@ export class WebGLPreview {
     });
   }
 
-  renderFrame(layerCount: number): void {
+  private renderFrame(layerCount: number): void {
     this.group = this.createGroup('layer' + this.renderLayerIndex);
 
     for (let l = 0; l < layerCount && this.renderLayerIndex + l < this.layers.length; l++) {
@@ -588,7 +568,7 @@ export class WebGLPreview {
   }
 
   // reset processing state
-  resetState(): void {
+  private resetState(): void {
     this.startLayer = 1;
     this.endLayer = Infinity;
     this.singleLayerMode = false;

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -385,15 +385,6 @@ export class WebGLPreview {
       this.renderLayer(index);
     }
 
-    this.group.quaternion.setFromEuler(new Euler(-Math.PI / 2, 0, 0));
-
-    if (this.buildVolume) {
-      this.group.position.set(-this.buildVolume.x / 2, 0, this.buildVolume.y / 2);
-    } else {
-      // FIXME: this is just a very crude approximation for centering
-      this.group.position.set(-100, 0, 100);
-    }
-
     this.batchGeometries();
 
     this.scene.add(this.group);

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -325,7 +325,7 @@ export class WebGLPreview {
 
   processGCode(gcode: string | string[]): void {
     this.parser.parseGCode(gcode);
-    this.renderIncremental();
+    this.render();
   }
 
   initScene() {

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -130,6 +130,8 @@ export class WebGLPreview {
 
   static readonly defaultExtrusionColor = new Color('hotpink');
 
+  prevLayerIndex?: number = undefined;
+
   private disposables: { dispose(): void }[] = [];
   private _extrusionColor: Color | Color[] = WebGLPreview.defaultExtrusionColor;
   private _backgroundColor = new Color(0xe0e0e0);
@@ -352,9 +354,8 @@ export class WebGLPreview {
 
   render(): void {
     const startRender = performance.now();
-    for (let index = 0; index < this.layers.length; index++) {
-      this.group = new Group();
-      this.group.name = 'layer' + index;
+    this.group = new Group();
+    for (let index = this.prevLayerIndex ?? 0; index < this.layers.length; index++) {
       this.renderLayer(index);
       this.group.quaternion.setFromEuler(new Euler(-Math.PI / 2, 0, 0));
 
@@ -379,6 +380,7 @@ export class WebGLPreview {
       this.renderer.render(this.scene, this.camera);
       this._lastRenderTime = performance.now() - startRender;
     }
+    this.prevLayerIndex = this.layers.length - 1;
   }
 
   renderLayer(index: number): void {

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -325,7 +325,7 @@ export class WebGLPreview {
 
   processGCode(gcode: string | string[]): void {
     this.parser.parseGCode(gcode);
-    this.renderNext();
+    this.renderIncremental();
   }
 
   initScene() {
@@ -349,7 +349,7 @@ export class WebGLPreview {
     }
 
     if (this.renderTubes) {
-      console.warn('Volumetric rendering is experimental and may not work as expected or change in the future.');
+      console.warn('Volumetric rendering is experimental. It may not work as expected or change in the future.');
       const light = new AmbientLight(0xcccccc, 0.3 * Math.PI);
       // threejs assumes meters but we use mm. So we need to scale the decay of the light
       const dLight = new PointLight(0xffffff, Math.PI, undefined, 1 / 1000);
@@ -372,7 +372,7 @@ export class WebGLPreview {
     return group;
   }
 
-  renderNext(): void {
+  renderIncremental(): void {
     // console.log('removing layer', this.prevLayerIndex);
     this.scene.remove(this.group);
     this.state = this.prevState ?? State.initial;
@@ -394,8 +394,8 @@ export class WebGLPreview {
 
   render(): void {
     const startRender = performance.now();
-    this.group = new Group();
-    this.group.name = 'gcode';
+    console.log('rendering all layers');
+    this.group = this.createGroup('allLayers');
     this.state = State.initial;
     this.initScene();
 

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -566,6 +566,7 @@ export class WebGLPreview {
     this.state = State.initial;
     this.devGui?.reset();
     this._geometries = {};
+    this.prevState = undefined;
   }
 
   resize(): void {

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -434,7 +434,6 @@ export class WebGLPreview {
       const loop = () => {
         if (this.renderLayerIndex > this.layers.length - 1) {
           resolve();
-          console.log('done rendering');
         } else {
           this.renderFrame(layerCount);
           requestAnimationFrame(loop);

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -401,11 +401,6 @@ export class WebGLPreview {
     this.state = State.initial;
     this.initScene();
 
-    while (this.disposables.length > 0) {
-      const disposable = this.disposables.pop();
-      if (disposable) disposable.dispose();
-    }
-
     for (let index = 0; index < this.layers.length; index++) {
       this.renderLayer(index);
     }


### PR DESCRIPTION
this is a partial fix for #124 

A new method was added: `renderAnimated `. This will render the layers progressively, to show progress while loading. Meant for large files that can take many seconds to render. 

the gradient can be maintained in the DEMO because we load the whole gcode in advance. So the gcode should be parsed as a whole before rendering. For true incremental rendering the gradient should be disabled.

Render progressively: 
- [x] when initially loading benchy
- [x] when dropping a new file
- [x] when choosing a file from the file selector
- [x] render progressively when toggling tubes
- [x] maintain gradient


