### PR TITLE
Feature/performance tweaks

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -194,6 +194,6 @@
   <script src="js/demo.js"></script>
   <script>
     const gcodeDemo = initDemo();
-    loadGCodeFromServer('square.gcode');
+    loadGCodeFromServer('rectangle.gcode');
   </script>
 </body>

--- a/demo/index.html
+++ b/demo/index.html
@@ -163,6 +163,10 @@
         </div>
 
       </section>
+      <section>
+        <button onclick="saveCameraPosition()">save camera</button>
+        <button onclick="loadCameraPosition()">load camera</button>
+      </section>
       <section style="display: none;">
         <button id=snapshot>Create snapshot</button>
       </section>

--- a/demo/index.html
+++ b/demo/index.html
@@ -190,6 +190,6 @@
   <script src="js/demo.js"></script>
   <script>
     const gcodeDemo = initDemo();
-    loadGCodeFromServer('3DBenchy-Multi-part.gcode');
+    loadGCodeFromServer('square.gcode');
   </script>
 </body>

--- a/demo/js/demo.js
+++ b/demo/js/demo.js
@@ -8,7 +8,7 @@ const maxToolCount = 8;
 let toolCount = 4;
 let chunkSize = 1000;
 let currentFile;
-const FILE_SIZE_5MB = 5 * 1024 * 1024;
+const FILE_SIZE_10MB = 10 * 1024 * 1024;
 
 const canvasElement = document.querySelector('.gcode-previewer');
 const startLayer = document.getElementById('start-layer');
@@ -132,7 +132,7 @@ function initDemo() {
 
   toggleRenderTubes.addEventListener('click', function () {
     preview.renderTubes = toggleRenderTubes.checked;
-    if (preview.renderTubes && currentFile.size > FILE_SIZE_5MB) {
+    if (preview.renderTubes && currentFile.size > FILE_SIZE_10MB) {
       confirm('This file is large and may take a while to render in this mode. Continue?')
         ? (preview.renderTubes = true)
         : (preview.renderTubes = false);
@@ -235,7 +235,7 @@ function initDemo() {
     fileSize.innerText = humanFileSize(file.size);
 
     preview.clear();
-    if (preview.renderTubes && file.size > FILE_SIZE_5MB) {
+    if (preview.renderTubes && file.size > FILE_SIZE_10MB) {
       confirm('This file is large and may take a while to render in this mode. Change to line rendering?')
         ? (preview.renderTubes = false)
         : (preview.renderTubes = true);

--- a/demo/js/demo.js
+++ b/demo/js/demo.js
@@ -242,10 +242,15 @@ function initDemo() {
     }
     preview.initScene();
     preview.clear();
-    // await preview._readFromStream(file.stream());
-    _handleGCode(file.name, await file.text());
+    console.time('readFromStream');
+    await preview._readFromStream(file.stream());
+    console.timeEnd('readFromStream');
     updateUI();
     currentFile = file;
+
+    console.time('render');
+    preview.render();
+    console.timeEnd('render');
   });
 
   function updateBuildVolume() {
@@ -376,7 +381,7 @@ async function loadGCodeFromServer(filename) {
 }
 
 function _handleGCode(filename, gcode) {
-  chunkSize = gcode.length / 1000;
+  // chunkSize = gcode.length / 1000;
   fileName.innerText = filename;
   fileSize.innerText = humanFileSize(gcode.length);
 

--- a/demo/js/demo.js
+++ b/demo/js/demo.js
@@ -63,7 +63,7 @@ function initDemo() {
     lastSegmentColor: '#fff',
     renderExtrusion: true,
     renderTravel: false,
-    renderTubes: false,
+    renderTubes: true,
     extrusionColor: ['hotpink', 'indigo', 'white', 'lime'],
     backgroundColor: preferDarkMode.matches ? '#111' : '#eee',
     travelColor: new THREE.Color('lime')

--- a/demo/js/demo.js
+++ b/demo/js/demo.js
@@ -4,9 +4,11 @@
 let gcodePreview;
 let favIcon;
 let thumb;
-let chunkSize = 10000;
 const maxToolCount = 8;
 let toolCount = 4;
+let chunkSize = 1000;
+let currentFile;
+const FILE_SIZE_5MB = 5 * 1024 * 1024;
 
 const canvasElement = document.querySelector('.gcode-previewer');
 const startLayer = document.getElementById('start-layer');
@@ -130,6 +132,12 @@ function initDemo() {
 
   toggleRenderTubes.addEventListener('click', function () {
     preview.renderTubes = toggleRenderTubes.checked;
+    if (preview.renderTubes && currentFile.size > FILE_SIZE_5MB) {
+      confirm('This file is large and may take a while to render in this mode. Continue?')
+        ? (preview.renderTubes = true)
+        : (preview.renderTubes = false);
+      toggleRenderTubes.checked = preview.renderTubes;
+    }
     preview.render();
   });
 
@@ -227,7 +235,7 @@ function initDemo() {
     fileSize.innerText = humanFileSize(file.size);
 
     preview.clear();
-    if (preview.renderTubes && file.size > 5 * 1024 * 1024) {
+    if (preview.renderTubes && file.size > FILE_SIZE_5MB) {
       confirm('This file is large and may take a while to render in this mode. Change to line rendering?')
         ? (preview.renderTubes = false)
         : (preview.renderTubes = true);
@@ -235,6 +243,7 @@ function initDemo() {
     preview.initScene();
     await preview._readFromStream(file.stream());
     updateUI();
+    currentFile = file;
     preview.render();
   });
 
@@ -354,7 +363,7 @@ function updateUI() {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
 async function loadGCodeFromServer(file) {
   const response = await fetch(file);
-
+  currentFile = file;
   if (response.status !== 200) {
     console.error('ERROR. Status Code: ' + response.status);
     return;

--- a/demo/js/demo.js
+++ b/demo/js/demo.js
@@ -62,7 +62,7 @@ function initDemo() {
     buildVolume: settings?.buildVolume || { x: 190, y: 210, z: 0 },
     initialCameraPosition: [180, 150, 300],
     // topLayerColor: 'rgb(0, 255, 255)',
-    lastSegmentColor: '#fff',
+    // lastSegmentColor: '#fff',
     renderExtrusion: true,
     renderTravel: false,
     renderTubes: true,

--- a/demo/js/demo.js
+++ b/demo/js/demo.js
@@ -6,7 +6,7 @@ let favIcon;
 let thumb;
 const maxToolCount = 8;
 let toolCount = 4;
-let chunkSize = 1000;
+const chunkSize = 1000;
 let currentFile;
 const FILE_SIZE_10MB = 10 * 1024 * 1024;
 
@@ -461,6 +461,7 @@ function showExtrusionColors() {
   }
 }
 
+// eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
 function saveCameraPosition() {
   localStorage.setItem('camera.hasPosition', 'true');
 
@@ -475,6 +476,7 @@ function saveCameraPosition() {
   localStorage.setItem('controls.target.z', gcodePreview.controls.target.z.toString());
 }
 
+// eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
 function loadCameraPosition() {
   if (localStorage.getItem('camera.hasPosition') !== 'true') return;
 

--- a/demo/js/demo.js
+++ b/demo/js/demo.js
@@ -460,3 +460,31 @@ function showExtrusionColors() {
     }
   }
 }
+
+function saveCameraPosition() {
+  localStorage.setItem('camera.hasPosition', 'true');
+
+  localStorage.setItem('camera.position.x', gcodePreview.camera.position.x.toString());
+  localStorage.setItem('camera.position.y', gcodePreview.camera.position.y.toString());
+  localStorage.setItem('camera.position.z', gcodePreview.camera.position.z.toString());
+  localStorage.setItem('camera.rotation.x', gcodePreview.camera.rotation.x.toString());
+  localStorage.setItem('camera.rotation.y', gcodePreview.camera.rotation.y.toString());
+  localStorage.setItem('camera.rotation.z', gcodePreview.camera.rotation.z.toString());
+  localStorage.setItem('controls.target.x', gcodePreview.controls.target.x.toString());
+  localStorage.setItem('controls.target.y', gcodePreview.controls.target.y.toString());
+  localStorage.setItem('controls.target.z', gcodePreview.controls.target.z.toString());
+}
+
+function loadCameraPosition() {
+  if (localStorage.getItem('camera.hasPosition') !== 'true') return;
+
+  gcodePreview.camera.position.x = parseFloat(localStorage.getItem('camera.position.x'));
+  gcodePreview.camera.position.y = parseFloat(localStorage.getItem('camera.position.y'));
+  gcodePreview.camera.position.z = parseFloat(localStorage.getItem('camera.position.z'));
+  gcodePreview.camera.rotation.x = parseFloat(localStorage.getItem('camera.rotation.x'));
+  gcodePreview.camera.rotation.y = parseFloat(localStorage.getItem('camera.rotation.y'));
+  gcodePreview.camera.rotation.z = parseFloat(localStorage.getItem('camera.rotation.z'));
+  gcodePreview.controls.target.x = parseFloat(localStorage.getItem('controls.target.x'));
+  gcodePreview.controls.target.y = parseFloat(localStorage.getItem('controls.target.y'));
+  gcodePreview.controls.target.z = parseFloat(localStorage.getItem('controls.target.z'));
+}

--- a/demo/js/demo.js
+++ b/demo/js/demo.js
@@ -234,17 +234,18 @@ function initDemo() {
     fileName.innerText = file.name;
     fileSize.innerText = humanFileSize(file.size);
 
-    preview.clear();
+    // preview.clear();
     if (preview.renderTubes && file.size > FILE_SIZE_10MB) {
       confirm('This file is large and may take a while to render in this mode. Change to line rendering?')
         ? (preview.renderTubes = false)
         : (preview.renderTubes = true);
     }
     preview.initScene();
-    await preview._readFromStream(file.stream());
+    preview.clear();
+    // await preview._readFromStream(file.stream());
+    _handleGCode(file.name, await file.text());
     updateUI();
     currentFile = file;
-    preview.render();
   });
 
   function updateBuildVolume() {
@@ -361,17 +362,17 @@ function updateUI() {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
-async function loadGCodeFromServer(file) {
-  const response = await fetch(file);
-  currentFile = file;
+async function loadGCodeFromServer(filename) {
+  const response = await fetch(filename);
+  currentFile = filename;
   if (response.status !== 200) {
     console.error('ERROR. Status Code: ' + response.status);
     return;
   }
 
   const gcode = await response.text();
-  _handleGCode(file, gcode);
-  fileName.setAttribute('href', file);
+  _handleGCode(filename, gcode);
+  fileName.setAttribute('href', filename);
 }
 
 function _handleGCode(filename, gcode) {
@@ -401,8 +402,7 @@ function startLoadingProgressive(gcode) {
       endLayer.removeAttribute('disabled');
     }
     gcodePreview.parser.parseGCode(chunk);
-    if (gcodePreview.renderTubes) gcodePreview.renderIncremental();
-    else gcodePreview.render();
+    gcodePreview.renderIncremental();
     updateUI();
   }
 

--- a/demo/rectangle.gcode
+++ b/demo/rectangle.gcode
@@ -2,10 +2,10 @@
 G0 Z0.2
 
 ; go to starting point
-G1 X20 Y20
+G1 X40 Y20
 
-; make a square
-G1 X20 Y10 E20
-G1 X10 Y10 E30
+; make a rectangle
+G1 X40 Y15 E20
+G1 X10 Y15 E30
 G1 X10 Y20 E40
-G1 X20 Y20 E50
+G1 X40 Y20 E50

--- a/demo/square.gcode
+++ b/demo/square.gcode
@@ -1,0 +1,11 @@
+; move z to start a new layer
+G0 Z0.2
+
+; go to starting point
+G1 X20 Y20
+
+; make a square
+G1 X20 Y10 E20
+G1 X10 Y10 E30
+G1 X10 Y20 E40
+G1 X20 Y20 E50

--- a/src/__tests__/webgl-preview.ts
+++ b/src/__tests__/webgl-preview.ts
@@ -87,7 +87,6 @@ test('cancelAnimation should cancel the render loop', async () => {
 function createMockPreview() {
   return {
     state: { x: 0, y: 0, z: 0, r: 0, e: 0, i: 0, j: 0 },
-
     minLayerIndex: 0,
     maxLayerIndex: Infinity,
     disposables: [

--- a/src/__tests__/webgl-preview.ts
+++ b/src/__tests__/webgl-preview.ts
@@ -2,7 +2,7 @@
 
 import { test, expect, vi, assert } from 'vitest';
 
-import { WebGLPreview } from '../webgl-preview';
+import { State, WebGLPreview } from '../webgl-preview';
 import { GCodeCommand } from '../gcode-parser';
 
 test('in gcode x,y,z params should update the state', () => {
@@ -86,7 +86,7 @@ test('cancelAnimation should cancel the render loop', async () => {
 
 function createMockPreview() {
   return {
-    state: { x: 0, y: 0, z: 0, r: 0, e: 0, i: 0, j: 0 },
+    state: State.initial,
     minLayerIndex: 0,
     maxLayerIndex: Infinity,
     disposables: [

--- a/src/gcode-parser.ts
+++ b/src/gcode-parser.ts
@@ -142,7 +142,7 @@ export class Parser {
   }
 
   private lines2commands(lines: string[]) {
-    return lines.map((l) => this.parseCommand(l)).filter((cmd) => cmd != null) as GCodeCommand[];
+    return lines.map((l) => this.parseCommand(l)) as GCodeCommand[];
   }
 
   private parseCommand(line: string, keepComments = true): GCodeCommand | null {

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -293,7 +293,7 @@ export class WebGLPreview {
 
   processGCode(gcode: string | string[]): void {
     this.parser.parseGCode(gcode);
-    this.renderNext();
+    this.renderIncremental();
   }
 
   initScene() {
@@ -317,7 +317,7 @@ export class WebGLPreview {
     }
 
     if (this.renderTubes) {
-      console.warn('Volumetric rendering is experimental and may not work as expected or change in the future.');
+      console.warn('Volumetric rendering is experimental. It may not work as expected or change in the future.');
       const light = new AmbientLight(0xcccccc, 0.3 * Math.PI);
       // threejs assumes meters but we use mm. So we need to scale the decay of the light
       const dLight = new PointLight(0xffffff, Math.PI, undefined, 1 / 1000);
@@ -340,7 +340,7 @@ export class WebGLPreview {
     return group;
   }
 
-  renderNext(): void {
+  renderIncremental(): void {
     // console.log('removing layer', this.prevLayerIndex);
     this.scene.remove(this.group);
     this.state = this.prevState ?? State.initial;
@@ -361,8 +361,8 @@ export class WebGLPreview {
   }
 
   render(): void {
-    this.group = new Group();
-    this.group.name = 'gcode';
+    console.log('rendering all layers');
+    this.group = this.createGroup('allLayers');
     this.state = State.initial;
     this.initScene();
 
@@ -397,6 +397,16 @@ export class WebGLPreview {
       z: this.state.z
     };
     const l = this.layers[index];
+    // if (index >= this.minLayerIndex) {
+    //   console.log(
+    //     'rendering layer',
+    //     index,
+    //     l.commands
+    //       .filter((c) => c.gcode)
+    //       .map((c) => c.src)
+    //       .join('\n')
+    //   );
+    // }
     for (const cmd of l.commands) {
       if (cmd.gcode == 'g20') {
         this.setInches();

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -93,7 +93,7 @@ export class WebGLPreview {
   scene: Scene;
   camera: PerspectiveCamera;
   renderer: WebGLRenderer;
-  group?: Group;
+  controls: OrbitControls;
   container?: HTMLElement;
   canvas: HTMLCanvasElement;
   renderExtrusion = true;
@@ -105,29 +105,31 @@ export class WebGLPreview {
   singleLayerMode = false;
   buildVolume?: BuildVolume;
   initialCameraPosition = [-100, 400, 450];
-  debug = false;
-  allowDragNDrop = false;
-  controls: OrbitControls;
-  beyondFirstMove = false;
+  debug = false; // deprecated
+  allowDragNDrop = false; // deprecated
   inches = false;
   nonTravelmoves: string[] = [];
-  _animationFrameId?: number;
   disableGradient = false;
 
+  // gcode processing state
   private state: State = State.initial;
-
-  static readonly defaultExtrusionColor = new Color('hotpink');
-
+  private prevState: State;
   private prevLayerIndex?: number = undefined;
+  private beyondFirstMove = false;
 
+  // rendering
+  private group?: Group;
   private disposables: { dispose(): void }[] = [];
+  static readonly defaultExtrusionColor = new Color('hotpink');
   private _extrusionColor: Color | Color[] = WebGLPreview.defaultExtrusionColor;
+  private animationFrameId?: number;
+
+  // colors
   private _backgroundColor = new Color(0xe0e0e0);
   private _travelColor = new Color(0x990000);
   private _topLayerColor?: Color;
   private _lastSegmentColor?: Color;
   private _toolColors: Record<number, Color> = {};
-  private prevState: State;
 
   constructor(opts: GCodePreviewOptions) {
     this.minLayerThreshold = opts.minLayerThreshold ?? this.minLayerThreshold;
@@ -286,7 +288,7 @@ export class WebGLPreview {
   }
 
   animate(): void {
-    this._animationFrameId = requestAnimationFrame(() => this.animate());
+    this.animationFrameId = requestAnimationFrame(() => this.animate());
     this.controls.update();
     this.renderer.render(this.scene, this.camera);
   }
@@ -714,8 +716,8 @@ export class WebGLPreview {
   }
 
   private cancelAnimation(): void {
-    if (this._animationFrameId !== undefined) cancelAnimationFrame(this._animationFrameId);
-    this._animationFrameId = undefined;
+    if (this.animationFrameId !== undefined) cancelAnimationFrame(this.animationFrameId);
+    this.animationFrameId = undefined;
   }
 
   private _enableDropHandler() {

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -199,6 +199,7 @@ export class WebGLPreview {
     this.resize();
 
     this.controls = new OrbitControls(this.camera, this.renderer.domElement);
+    this.initScene();
     this.animate();
 
     if (this.allowDragNDrop) this._enableDropHandler();
@@ -286,7 +287,7 @@ export class WebGLPreview {
     this.render();
   }
 
-  render(): void {
+  initScene() {
     while (this.scene.children.length > 0) {
       this.scene.remove(this.scene.children[0]);
     }
@@ -315,25 +316,25 @@ export class WebGLPreview {
       this.scene.add(light);
       this.scene.add(dLight);
     }
+  }
 
-    this.group = new Group();
-    this.group.name = 'gcode';
-
+  render(): void {
     for (let index = 0; index < this.layers.length; index++) {
+      this.group = new Group();
+      this.group.name = 'layer' + index;
       this.renderLayer(index);
+      this.group.quaternion.setFromEuler(new Euler(-Math.PI / 2, 0, 0));
+
+      if (this.buildVolume) {
+        this.group.position.set(-this.buildVolume.x / 2, 0, this.buildVolume.y / 2);
+      } else {
+        // FIXME: this is just a very crude approximation for centering
+        this.group.position.set(-100, 0, 100);
+      }
+
+      this.scene.add(this.group);
+      this.renderer.render(this.scene, this.camera);
     }
-
-    this.group.quaternion.setFromEuler(new Euler(-Math.PI / 2, 0, 0));
-
-    if (this.buildVolume) {
-      this.group.position.set(-this.buildVolume.x / 2, 0, this.buildVolume.y / 2);
-    } else {
-      // FIXME: this is just a very crude approximation for centering
-      this.group.position.set(-100, 0, 100);
-    }
-
-    this.scene.add(this.group);
-    this.renderer.render(this.scene, this.camera);
   }
 
   renderLayer(index: number): void {

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -515,7 +515,7 @@ export class WebGLPreview {
     this.singleLayerMode = false;
     this.parser = new Parser(this.minLayerThreshold);
     this.beyondFirstMove = false;
-    this.state = { x: 0, y: 0, z: 0, r: 0, e: 0, i: 0, j: 0, t: 0 };
+    this.state = State.initial;
   }
 
   resize(): void {
@@ -754,6 +754,7 @@ export class WebGLPreview {
     let tail = '';
     let size = 0;
     do {
+      console.debug('reading from stream');
       result = await reader.read();
       size += result.value?.length ?? 0;
       const str = decode(result.value);

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -108,11 +108,11 @@ export class WebGLPreview {
   _animationFrameId?: number;
   disableGradient = false;
 
-  state: State = { x: 0, y: 0, z: 0, r: 0, e: 0, i: 0, j: 0, t: 0 };
+  private state: State = { x: 0, y: 0, z: 0, r: 0, e: 0, i: 0, j: 0, t: 0 };
 
   static readonly defaultExtrusionColor = new Color('hotpink');
 
-  prevLayerIndex?: number = undefined;
+  private prevLayerIndex?: number = undefined;
 
   private disposables: { dispose(): void }[] = [];
   private _extrusionColor: Color | Color[] = WebGLPreview.defaultExtrusionColor;
@@ -121,6 +121,7 @@ export class WebGLPreview {
   private _topLayerColor?: Color;
   private _lastSegmentColor?: Color;
   private _toolColors: Record<number, Color> = {};
+  private prevState: State;
 
   constructor(opts: GCodePreviewOptions) {
     this.minLayerThreshold = opts.minLayerThreshold ?? this.minLayerThreshold;
@@ -286,7 +287,7 @@ export class WebGLPreview {
 
   processGCode(gcode: string | string[]): void {
     this.parser.parseGCode(gcode);
-    this.render();
+    this.renderNext();
   }
 
   initScene() {
@@ -320,23 +321,65 @@ export class WebGLPreview {
     }
   }
 
-  render(): void {
-    this.group = new Group();
-    for (let index = this.prevLayerIndex ?? 0; index < this.layers.length; index++) {
-      this.renderLayer(index);
-      this.group.quaternion.setFromEuler(new Euler(-Math.PI / 2, 0, 0));
+  createGroup(name: string): Group {
+    const group = new Group();
+    group.name = name;
+    group.quaternion.setFromEuler(new Euler(-Math.PI / 2, 0, 0));
+    if (this.buildVolume) {
+      group.position.set(-this.buildVolume.x / 2, 0, this.buildVolume.y / 2);
+    } else {
+      // FIXME: this is just a very crude approximation for centering
+      group.position.set(-100, 0, 100);
+    }
+    return group;
+  }
 
-      if (this.buildVolume) {
-        this.group.position.set(-this.buildVolume.x / 2, 0, this.buildVolume.y / 2);
-      } else {
-        // FIXME: this is just a very crude approximation for centering
-        this.group.position.set(-100, 0, 100);
-      }
+  renderNext(): void {
+    // console.log('removing layer', this.prevLayerIndex);
+    this.scene.remove(this.group);
+    this.state = this.prevState;
+
+    for (let index = this.prevLayerIndex ?? 0; index < this.layers.length; index++) {
+      this.group = this.createGroup('layer' + index);
+      // console.log('rendering layer', index);
+
+      this.prevState = { ...this.state };
+      this.renderLayer(index);
 
       this.scene.add(this.group);
-      this.renderer.render(this.scene, this.camera);
     }
+
+    this.renderer.render(this.scene, this.camera);
+
     this.prevLayerIndex = this.layers.length - 1;
+  }
+
+  render(): void {
+    this.group = new Group();
+    this.group.name = 'gcode';
+    this.state = { x: 0, y: 0, z: 0, r: 0, e: 0, i: 0, j: 0, t: 0 };
+    this.initScene();
+
+    while (this.disposables.length > 0) {
+      const disposable = this.disposables.pop();
+      if (disposable) disposable.dispose();
+    }
+
+    for (let index = 0; index < this.layers.length; index++) {
+      this.renderLayer(index);
+    }
+
+    this.group.quaternion.setFromEuler(new Euler(-Math.PI / 2, 0, 0));
+
+    if (this.buildVolume) {
+      this.group.position.set(-this.buildVolume.x / 2, 0, this.buildVolume.y / 2);
+    } else {
+      // FIXME: this is just a very crude approximation for centering
+      this.group.position.set(-100, 0, 100);
+    }
+
+    this.scene.add(this.group);
+    this.renderer.render(this.scene, this.camera);
   }
 
   renderLayer(index: number): void {

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -202,7 +202,7 @@ export class WebGLPreview {
       });
     }
 
-    this.camera = new PerspectiveCamera(25, this.canvas.offsetWidth / this.canvas.offsetHeight, 10, 5000);
+    this.camera = new PerspectiveCamera(25, this.canvas.offsetWidth / this.canvas.offsetHeight, 2, 5000);
     this.camera.position.fromArray(this.initialCameraPosition);
     const fogFar = (this.camera as PerspectiveCamera).far;
     const fogNear = fogFar * 0.8;
@@ -467,7 +467,7 @@ export class WebGLPreview {
         extrusionColor = new Color().setHSL(target.h, target.s, brightness);
       }
 
-      if (index == this.layers.length - 1) {
+      if (index == this.layers.length - 1 && this._topLayerColor) {
         const layerColor = this._topLayerColor ?? extrusionColor;
         const lastSegmentColor = this._lastSegmentColor ?? layerColor;
 
@@ -679,6 +679,7 @@ export class WebGLPreview {
     if (curvePoints.length > 1) {
       curves.push(new CatmullRomCurve3(curvePoints, false, 'catmullrom', 0));
     }
+
     console.log('# curves', curves.length);
     curves.forEach((curve) => {
       const material = new MeshLambertMaterial({ color: color });

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -39,7 +39,7 @@ type Arc = GVector3 & { r: number; i: number; j: number };
 
 type Point = GVector3;
 type BuildVolume = GVector3;
-export type State = {
+export class State {
   x: number;
   y: number;
   z: number;
@@ -48,7 +48,13 @@ export type State = {
   i: number;
   j: number;
   t: number; // tool index
-}; // feedrate?
+  // feedrate?
+  static get initial(): State {
+    const state = new State();
+    Object.assign(state, { x: 0, y: 0, z: 0, r: 0, e: 0, i: 0, j: 0, t: 0 });
+    return state;
+  }
+}
 
 export type GCodePreviewOptions = {
   allowDragNDrop?: boolean;
@@ -108,7 +114,7 @@ export class WebGLPreview {
   _animationFrameId?: number;
   disableGradient = false;
 
-  private state: State = { x: 0, y: 0, z: 0, r: 0, e: 0, i: 0, j: 0, t: 0 };
+  private state: State = State.initial;
 
   static readonly defaultExtrusionColor = new Color('hotpink');
 
@@ -337,7 +343,7 @@ export class WebGLPreview {
   renderNext(): void {
     // console.log('removing layer', this.prevLayerIndex);
     this.scene.remove(this.group);
-    this.state = this.prevState;
+    this.state = this.prevState ?? State.initial;
 
     for (let index = this.prevLayerIndex ?? 0; index < this.layers.length; index++) {
       this.group = this.createGroup('layer' + index);
@@ -357,7 +363,7 @@ export class WebGLPreview {
   render(): void {
     this.group = new Group();
     this.group.name = 'gcode';
-    this.state = { x: 0, y: 0, z: 0, r: 0, e: 0, i: 0, j: 0, t: 0 };
+    this.state = State.initial;
     this.initScene();
 
     while (this.disposables.length > 0) {

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -18,7 +18,6 @@ import {
   Group,
   LineBasicMaterial,
   LineSegments,
-  Mesh,
   MeshLambertMaterial,
   PerspectiveCamera,
   PointLight,

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -112,6 +112,9 @@ export class WebGLPreview {
 
   static readonly defaultExtrusionColor = new Color('hotpink');
 
+  state: State = { x: 0, y: 0, z: 0, r: 0, e: 0, i: 0, j: 0 };
+  prevLayerIndex?: number = undefined;
+
   private disposables: { dispose(): void }[] = [];
   private _extrusionColor: Color | Color[] = WebGLPreview.defaultExtrusionColor;
   private _backgroundColor = new Color(0xe0e0e0);
@@ -319,9 +322,8 @@ export class WebGLPreview {
   }
 
   render(): void {
-    for (let index = 0; index < this.layers.length; index++) {
-      this.group = new Group();
-      this.group.name = 'layer' + index;
+    this.group = new Group();
+    for (let index = this.prevLayerIndex ?? 0; index < this.layers.length; index++) {
       this.renderLayer(index);
       this.group.quaternion.setFromEuler(new Euler(-Math.PI / 2, 0, 0));
 
@@ -335,6 +337,7 @@ export class WebGLPreview {
       this.scene.add(this.group);
       this.renderer.render(this.scene, this.camera);
     }
+    this.prevLayerIndex = this.layers.length - 1;
   }
 
   renderLayer(index: number): void {

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -112,7 +112,6 @@ export class WebGLPreview {
 
   static readonly defaultExtrusionColor = new Color('hotpink');
 
-  state: State = { x: 0, y: 0, z: 0, r: 0, e: 0, i: 0, j: 0 };
   prevLayerIndex?: number = undefined;
 
   private disposables: { dispose(): void }[] = [];

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -518,6 +518,7 @@ export class WebGLPreview {
     this.parser = new Parser(this.minLayerThreshold);
     this.beyondFirstMove = false;
     this.state = State.initial;
+    this.prevState = undefined;
   }
 
   resize(): void {

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -293,7 +293,7 @@ export class WebGLPreview {
 
   processGCode(gcode: string | string[]): void {
     this.parser.parseGCode(gcode);
-    this.renderIncremental();
+    this.render();
   }
 
   initScene() {
@@ -397,16 +397,6 @@ export class WebGLPreview {
       z: this.state.z
     };
     const l = this.layers[index];
-    // if (index >= this.minLayerIndex) {
-    //   console.log(
-    //     'rendering layer',
-    //     index,
-    //     l.commands
-    //       .filter((c) => c.gcode)
-    //       .map((c) => c.src)
-    //       .join('\n')
-    //   );
-    // }
     for (const cmd of l.commands) {
       if (cmd.gcode == 'g20') {
         this.setInches();


### PR DESCRIPTION
Investigating the performance of the TubeGeometry leads me to believe that
- the # of tube segments is a large contributor to the overall mesh size
- we're creating more tube segments than necessary. 

The screenshot it shows that the tube is divided evenly along its length while we need more division towards the corners and less far away form the corners. 

This has to do with how a curve is divided. In turn this is based on where the [FrenetFrames are defined](https://github.com/mrdoob/three.js/blob/dev/src/geometries/TubeGeometry.js#L23) along the path of the curve.

The maximum bend radius of a corner should be equal to the line width, as set in the slicer. This means that no extra segments are needed at a distance of line-width/2 from the corners.

<img width="766" alt="image" src="https://github.com/remcoder/gcode-preview/assets/461650/1a0b083c-c234-44ad-95bd-31fbe9e581a9">
