### PR TITLE
Tube's diameter set by an Extrusion Width parameter

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -65,11 +65,12 @@
           />
         </div>
         <div class="controls">
-          <label>Tube line width <output id="tube-line-width-value" ></output></label>&nbsp;<input
+          <label>Tube width <output id="tube-line-width-value" ></output></label>&nbsp;<input
             type="range"
             min="0.05"
-            max="30"
+            max="3.0"
             value="0.6"
+            step="0.05"
             id="tube-line-width"
           />
         </div>
@@ -118,7 +119,7 @@
         </div>
         <div class="controls">
           <label for="extrusion-color-t6">Extrusion color (T6)</label>
-          <input type="color" id="extrusion-color-t6" value="#ff0000" />  
+          <input type="color" id="extrusion-color-t6" value="#ff0000" />
         </div>
         <div class="controls">
           <label for="extrusion-color-t7">Extrusion color (T7)</label>

--- a/demo/index.html
+++ b/demo/index.html
@@ -65,13 +65,13 @@
           />
         </div>
         <div class="controls">
-          <label>Tube width <output id="tube-line-width-value" ></output></label>&nbsp;<input
+          <label>Tube width <output id="extrusion-width-value" ></output></label>&nbsp;<input
             type="range"
             min="0.05"
             max="3.0"
             value="0.6"
             step="0.05"
-            id="tube-line-width"
+            id="extrusion-width"
           />
         </div>
         <div class="controls">

--- a/demo/index.html
+++ b/demo/index.html
@@ -65,6 +65,15 @@
           />
         </div>
         <div class="controls">
+          <label>Tube line width <output id="tube-line-width-value" ></output></label>&nbsp;<input
+            type="range"
+            min="0.05"
+            max="30"
+            value="0.6"
+            id="tube-line-width"
+          />
+        </div>
+        <div class="controls">
           <label for="single-layer-mode">Single layer mode</label
           ><input type="checkbox" id="single-layer-mode" />
         </div>

--- a/demo/js/demo.js
+++ b/demo/js/demo.js
@@ -15,8 +15,8 @@ const endLayer = document.getElementById('end-layer');
 const endLayerValue = document.getElementById('end-layer-value');
 const lineWidth = document.getElementById('line-width');
 const lineWidthValue = document.getElementById('line-width-value');
-const tubeLineWidth = document.getElementById('tube-line-width');
-const tubeLineWidthValue = document.getElementById('tube-line-width-value');
+const extrusionWidth = document.getElementById('extrusion-width');
+const extrusionWidthValue = document.getElementById('extrusion-width-value');
 const toggleSingleLayerMode = document.getElementById('single-layer-mode');
 const toggleExtrusion = document.getElementById('extrusion');
 const toggleRenderTubes = document.getElementById('render-tubes');
@@ -115,9 +115,9 @@ function initDemo() {
     preview.render();
   });
 
-  tubeLineWidth.addEventListener('input', function () {
-    preview.tubeLineWidth = +tubeLineWidth.value;
-    tubeLineWidthValue.innerText = tubeLineWidth.value;
+  extrusionWidth.addEventListener('input', function () {
+    preview.extrusionWidth = +extrusionWidth.value;
+    extrusionWidthValue.innerText = extrusionWidth.value;
     preview.render();
   });
 

--- a/demo/js/demo.js
+++ b/demo/js/demo.js
@@ -15,6 +15,8 @@ const endLayer = document.getElementById('end-layer');
 const endLayerValue = document.getElementById('end-layer-value');
 const lineWidth = document.getElementById('line-width');
 const lineWidthValue = document.getElementById('line-width-value');
+const tubeLineWidth = document.getElementById('tube-line-width');
+const tubeLineWidthValue = document.getElementById('tube-line-width-value');
 const toggleSingleLayerMode = document.getElementById('single-layer-mode');
 const toggleExtrusion = document.getElementById('extrusion');
 const toggleRenderTubes = document.getElementById('render-tubes');
@@ -110,6 +112,12 @@ function initDemo() {
   lineWidth.addEventListener('input', function () {
     preview.lineWidth = +lineWidth.value;
     lineWidthValue.innerText = lineWidth.value;
+    preview.render();
+  });
+
+  tubeLineWidth.addEventListener('input', function () {
+    preview.tubeLineWidth = +tubeLineWidth.value;
+    tubeLineWidthValue.innerText = tubeLineWidth.value;
     preview.render();
   });
 

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -72,7 +72,7 @@ export type GCodePreviewOptions = {
   travelColor?: ColorRepresentation;
   toolColors?: Record<number, ColorRepresentation>;
   disableGradient?: boolean;
-  tubeLineWidth?: number;
+  extrusionWidth?: number;
 };
 
 const target = {
@@ -94,7 +94,7 @@ export class WebGLPreview {
   renderExtrusion = true;
   renderTravel = false;
   renderTubes = false;
-  tubeLineWidth = 0.6;
+  extrusionWidth = 0.6;
   lineWidth?: number;
   startLayer?: number;
   endLayer?: number;
@@ -142,7 +142,7 @@ export class WebGLPreview {
     this.renderTravel = opts.renderTravel ?? this.renderTravel;
     this.nonTravelmoves = opts.nonTravelMoves ?? this.nonTravelmoves;
     this.renderTubes = opts.renderTubes ?? this.renderTubes;
-    this.tubeLineWidth = opts.tubeLineWidth ?? this.tubeLineWidth;
+    this.extrusionWidth = opts.extrusionWidth ?? this.extrusionWidth;
 
     if (opts.extrusionColor !== undefined) {
       this.extrusionColor = opts.extrusionColor;
@@ -629,7 +629,7 @@ export class WebGLPreview {
       const material = new MeshLambertMaterial({ color: color });
       this.disposables.push(material);
       const segments = Math.ceil(curve.getLength() * 2);
-      const geometry = new TubeGeometry(curve, segments, this.tubeLineWidth / 2, 4, false);
+      const geometry = new TubeGeometry(curve, segments, this.extrusionWidth / 2, 4, false);
       this.disposables.push(geometry);
       const lineSegments = new Mesh(geometry, material);
 

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -72,6 +72,7 @@ export type GCodePreviewOptions = {
   travelColor?: ColorRepresentation;
   toolColors?: Record<number, ColorRepresentation>;
   disableGradient?: boolean;
+  tubeLineWidth?: number;
 };
 
 const target = {
@@ -93,6 +94,7 @@ export class WebGLPreview {
   renderExtrusion = true;
   renderTravel = false;
   renderTubes = false;
+  tubeLineWidth = 0.6;
   lineWidth?: number;
   startLayer?: number;
   endLayer?: number;
@@ -140,6 +142,7 @@ export class WebGLPreview {
     this.renderTravel = opts.renderTravel ?? this.renderTravel;
     this.nonTravelmoves = opts.nonTravelMoves ?? this.nonTravelmoves;
     this.renderTubes = opts.renderTubes ?? this.renderTubes;
+    this.tubeLineWidth = opts.tubeLineWidth ?? this.tubeLineWidth;
 
     if (opts.extrusionColor !== undefined) {
       this.extrusionColor = opts.extrusionColor;
@@ -626,7 +629,7 @@ export class WebGLPreview {
       const material = new MeshLambertMaterial({ color: color });
       this.disposables.push(material);
       const segments = Math.ceil(curve.getLength() * 2);
-      const geometry = new TubeGeometry(curve, segments, 0.3, 4, false);
+      const geometry = new TubeGeometry(curve, segments, this.tubeLineWidth / 2, 4, false);
       this.disposables.push(geometry);
       const lineSegments = new Mesh(geometry, material);
 


### PR DESCRIPTION
Part of https://github.com/remcoder/gcode-preview/issues/96

As discussed about a month or two ago on Discord, this is a first and tiny step towards dynamic tube diameter for tube rendering. 

The next steps are more complicated and require some logic and decisions that would be too much to all put in the same PR. So I'm going incrementally.  

The next step would be to try and have the layer height as well, in order to change the tube's height. With those two parameters that can be explicitly set, it unlocks fetching values from the gcode instead of hardcoded values as the default.

>[!NOTE]
> In the demo, I used the label "Tube width" instead of "Tube line width" as a shortcut to fix a display issue, it was to long for the horizontal space of the sidebar.