### PR TITLE
Fix readonly type

### DIFF
--- a/src/extrusion-geometry.ts
+++ b/src/extrusion-geometry.ts
@@ -8,6 +8,9 @@ class ExtrusionGeometry extends BufferGeometry {
     radialSegments: number;
     closed: boolean;
   };
+
+  readonly type: string;
+
   constructor(
     points: Vector3[] = [new Vector3()],
     lineWidth: number = 0.6,


### PR DESCRIPTION
Fixes an issue that went unnoticed when earlier versions  of`@types/three` is installed. It produced this error:

```
[!] (plugin rpt2) Error: src/extrusion-geometry.ts:19:10 - error TS2540: Cannot assign to 'type' because it is a read-only property.

19     this.type = 'ExtrusionGeometry';
            ~~~~

src/gcode-preview.ts
```