### PR TITLE
Layer height

### DIFF
--- a/demo/js/demo.js
+++ b/demo/js/demo.js
@@ -158,7 +158,8 @@ function initDemo() {
     canvas: canvasElement,
     buildVolume: settings?.buildVolume || { x: 190, y: 210, z: 0 },
     initialCameraPosition: [180, 150, 300],
-    backgroundColor: initialBackgroundColor
+    backgroundColor: initialBackgroundColor,
+    lineHeight: 0.3
   }));
 
   backgroundColor.value = initialBackgroundColor;

--- a/src/__tests__/gcode-parser.ts
+++ b/src/__tests__/gcode-parser.ts
@@ -121,6 +121,25 @@ test('2 extrusion moves with a z diff exactly at the threshold should result in 
   expect(parsed.layers[0].commands.length).toEqual(2);
 });
 
+test('Layers should have calculated heights', () => {
+  const threshold = 0.05;
+  const parser = new Parser(threshold);
+  const gcode = `G0 X0 Y0 Z0.1 E1
+  G1 X10 Y10 Z0.2 E2
+  G1 X20 Y20 Z0.3 E3
+  G1 X30 Y30 Z0.5 E4
+  G1 X40 Y40 Z0.8 E5
+  `;
+  const parsed = parser.parseGCode(gcode);
+  expect(parsed).not.toBeNull();
+  expect(parsed.layers).not.toBeNull();
+  expect(parsed.layers.length).toEqual(5);
+  expect(parsed.layers[0].height).toEqual(expect.closeTo(0.1, 3));
+  expect(parsed.layers[1].height).toEqual(expect.closeTo(0.1, 3));
+  expect(parsed.layers[2].height).toEqual(expect.closeTo(0.1, 3));
+  expect(parsed.layers[3].height).toEqual(expect.closeTo(0.2, 3));
+});
+
 test('T0 command should result in a tool change to tool with index 0', () => {
   const parser = new Parser(0);
   const gcode = `G1 X0 Y0 Z1 E1

--- a/src/gcode-parser.ts
+++ b/src/gcode-parser.ts
@@ -97,7 +97,8 @@ export class Layer {
   constructor(
     public layer: number,
     public commands: GCodeCommand[],
-    public lineNumber: number
+    public lineNumber: number,
+    public height: number = 0
   ) {}
 }
 
@@ -106,7 +107,7 @@ export class Parser {
   preamble = new Layer(-1, [], 0); // TODO: remove preamble and treat as a regular layer? Unsure of the benefit
   layers: Layer[] = [];
   curZ = 0;
-  maxZ = -Infinity; // cannot start at 0 because of tolerance. first layer will always be created
+  maxZ = 0; // cannot start at 0 because of tolerance. first layer will always be created
   metadata: Metadata = { thumbnails: {} };
   tolerance = 0; // The higher the tolerance, the fewer layers are created, so performance will improve.
 
@@ -232,10 +233,11 @@ export class Parser {
         if (
           (params.e ?? 0) > 0 && // extruding?
           (params.x != undefined || params.y != undefined) && // moving?
-          Math.abs(this.curZ - this.maxZ) > this.tolerance // new layer?
+          Math.abs(this.curZ - (this.maxZ || -Infinity)) > this.tolerance // new layer?
         ) {
+          const layerHeight = Math.abs(this.curZ - this.maxZ);
           this.maxZ = this.curZ;
-          this.layers.push(new Layer(this.layers.length, [], lineNumber));
+          this.layers.push(new Layer(this.layers.length, [], lineNumber, layerHeight));
         }
       }
 

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -29,7 +29,7 @@ import {
 
 import { ExtrusionGeometry } from './extrusion-geometry';
 
-type RenderLayer = { extrusion: number[]; travel: number[]; z: number };
+type RenderLayer = { extrusion: number[]; travel: number[]; z: number; height: number };
 type GVector3 = {
   x: number;
   y: number;
@@ -341,13 +341,15 @@ export class WebGLPreview {
 
   renderLayer(index: number): void {
     if (index > this.maxLayerIndex) return;
+    const l = this.layers[index];
 
     const currentLayer: RenderLayer = {
       extrusion: [],
       travel: [],
-      z: this.state.z
+      z: this.state.z,
+      height: l.height
     };
-    const l = this.layers[index];
+
     for (const cmd of l.commands) {
       if (cmd.gcode == 'g20') {
         this.setInches();
@@ -421,15 +423,15 @@ export class WebGLPreview {
         const endPoint = layer.extrusion.splice(-3);
         const preendPoint = layer.extrusion.splice(-3);
         if (this.renderTubes) {
-          this.addTubeLine(layer.extrusion, layerColor.getHex());
-          this.addTubeLine([...preendPoint, ...endPoint], lastSegmentColor.getHex());
+          this.addTubeLine(layer.extrusion, layerColor.getHex(), layer.height);
+          this.addTubeLine([...preendPoint, ...endPoint], lastSegmentColor.getHex(), layer.height);
         } else {
           this.addLine(layer.extrusion, layerColor.getHex());
           this.addLine([...preendPoint, ...endPoint], lastSegmentColor.getHex());
         }
       } else {
         if (this.renderTubes) {
-          this.addTubeLine(layer.extrusion, extrusionColor.getHex());
+          this.addTubeLine(layer.extrusion, extrusionColor.getHex(), layer.height);
         } else {
           this.addLine(layer.extrusion, extrusionColor.getHex());
         }
@@ -598,7 +600,7 @@ export class WebGLPreview {
     this.group?.add(lineSegments);
   }
 
-  addTubeLine(vertices: number[], color: number): void {
+  addTubeLine(vertices: number[], color: number, layerHeight = 0.2): void {
     let curvePoints: Vector3[] = [];
     const extrusionPaths: Vector3[][] = [];
 
@@ -619,7 +621,7 @@ export class WebGLPreview {
     }
 
     extrusionPaths.forEach((extrusionPath) => {
-      const geometry = new ExtrusionGeometry(extrusionPath, this.extrusionWidth, 0.2, 4);
+      const geometry = new ExtrusionGeometry(extrusionPath, this.extrusionWidth, layerHeight, 4);
       this.disposables.push(geometry);
 
       const material = new MeshLambertMaterial({ color: color });

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -61,6 +61,7 @@ export type GCodePreviewOptions = {
   initialCameraPosition?: number[];
   lastSegmentColor?: ColorRepresentation;
   lineWidth?: number;
+  lineHeight?: number;
   nonTravelMoves?: string[];
   minLayerThreshold?: number;
   renderExtrusion?: boolean;
@@ -96,6 +97,7 @@ export class WebGLPreview {
   renderTubes = false;
   extrusionWidth = 0.6;
   lineWidth?: number;
+  lineHeight?: number;
   startLayer?: number;
   endLayer?: number;
   singleLayerMode = false;
@@ -134,6 +136,7 @@ export class WebGLPreview {
     this.endLayer = opts.endLayer;
     this.startLayer = opts.startLayer;
     this.lineWidth = opts.lineWidth;
+    this.lineHeight = opts.lineHeight;
     this.buildVolume = opts.buildVolume;
     this.initialCameraPosition = opts.initialCameraPosition ?? this.initialCameraPosition;
     this.debug = opts.debug ?? this.debug;
@@ -621,7 +624,7 @@ export class WebGLPreview {
     }
 
     extrusionPaths.forEach((extrusionPath) => {
-      const geometry = new ExtrusionGeometry(extrusionPath, this.extrusionWidth, layerHeight, 4);
+      const geometry = new ExtrusionGeometry(extrusionPath, this.extrusionWidth, this.lineHeight || layerHeight, 4);
       this.disposables.push(geometry);
 
       const material = new MeshLambertMaterial({ color: color });


### PR DESCRIPTION
Closes #96 

The logic is simple to start with. The parser calculates the height of each layer.

There's a public option to override calculated layer height. The idea is to fix whatever the parser gets wrong, like in vase mode. This is why the demo passes an harcoded value. I'm not sure how I would like to approach providing that control on a demo because it should allow an undefined value for most cases. Maybe a number box? Does it even belong on the demo? It has a really small impact on the overall appreciation of features, so it would be adding noise.

