### PR TITLE
Export type GCodePreviewOptions

### DIFF
--- a/src/gcode-preview.ts
+++ b/src/gcode-preview.ts
@@ -4,4 +4,4 @@ import { DevModeOptions } from './dev-gui';
 const init = function (opts: GCodePreviewOptions) {
   return new WebGLPreview(opts);
 };
-export { WebGLPreview, init, DevModeOptions };
+export { WebGLPreview, init, DevModeOptions, GCodePreviewOptions };


### PR DESCRIPTION
This exports the type for the options object so consumers will enjoy type safety. Additionally, it causes the options object to be included in the api docs.

fixes #174 