### PR TITLE
Fix/stats counter position

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -27,10 +27,10 @@
 
   <div class="dnd">☝️ Drop a gcode file here to view it</div>
   <div class="version-box">
-
     <script type="text/javascript" src="https://cdnjs.buymeacoffee.com/1.0.0/button.prod.min.js" data-name="bmc-button" data-slug="remcoder" data-color="#303030" data-emoji=""  data-font="Lato" data-text="Buy me a coffee" data-outline-color="#ffffff" data-font-color="#ffffff" data-coffee-color="#FFDD00" ></script>
-</div>
+  </div>
   <div class="sidebar">
+   <div class="scroll-container">
     <div>
       <h1>GCode Preview</h1>
       Presets:
@@ -214,6 +214,7 @@
           </a>
       </section>
     </div>
+   </div>
   </div>
 
   <!-- <script src="js/canvas2image.js"></script> -->

--- a/demo/js/demo.js
+++ b/demo/js/demo.js
@@ -160,7 +160,14 @@ export function initDemo() {
     initialCameraPosition: [180, 150, 300],
     backgroundColor: initialBackgroundColor,
     lineHeight: 0.3,
-    devMode: true
+    devMode: {
+      camera: true,
+      renderer: true,
+      parser: true,
+      buildVolume: true,
+      devHelpers: true,
+      statsContainer: document.querySelector('.sidebar')
+    }
   }));
 
   backgroundColor.value = initialBackgroundColor;

--- a/demo/style.css
+++ b/demo/style.css
@@ -33,15 +33,20 @@ body {
   left: 0;
   top: 0;
   bottom: 0;
-  padding: 10px;
   line-height: 25px;
   transform: translateZ(0);
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   transform: translateZ(0);
+}
+
+.scroll-container {
+  padding: 10px;
+
   overflow-y: scroll;
   overflow-x: hidden;
+  height: 100%;
 }
 
 .description {
@@ -182,4 +187,10 @@ output {
   line-height: 10px;
   position: relative;
   bottom: 2px;
+}
+
+.stats {
+  position: absolute !important;
+  right: -80px !important;
+  left: unset !important;
 }

--- a/src/dev-gui.ts
+++ b/src/dev-gui.ts
@@ -6,6 +6,7 @@ export type DevModeOptions = {
   parser?: boolean | false;
   buildVolume?: boolean | false;
   devHelpers?: boolean | false;
+  statsContainer?: HTMLElement | undefined;
 };
 
 class DevGUI {

--- a/src/dev-gui.ts
+++ b/src/dev-gui.ts
@@ -56,7 +56,6 @@ class DevGUI {
 
   loadOpenFolders(): void {
     this.openFolders = JSON.parse(localStorage.getItem('dev-gui-open') || '{}').open || [];
-    console.log(this.openFolders);
   }
 
   saveOpenFolders(): void {

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -156,7 +156,8 @@ export class WebGLPreview {
   private devMode?: boolean | DevModeOptions = true;
   private _lastRenderTime = 0;
   private _wireframe = false;
-  private stats: Stats = this.devMode ? new Stats() : undefined;
+  private stats?: Stats = this.devMode ? new Stats() : undefined;
+  private statsContainer?: HTMLElement;
   private devGui?: DevGUI;
 
   constructor(opts: GCodePreviewOptions) {
@@ -245,10 +246,7 @@ export class WebGLPreview {
 
     if (opts.allowDragNDrop) this._enableDropHandler();
 
-    if (this.stats) {
-      document.body.appendChild(this.stats.dom);
-      this.initGui();
-    }
+    this.initStats();
   }
 
   get extrusionColor(): Color | Color[] {
@@ -855,6 +853,17 @@ export class WebGLPreview {
       this.devGui = new DevGUI(this);
     } else if (typeof this.devMode === 'object') {
       this.devGui = new DevGUI(this, this.devMode);
+    }
+  }
+
+  private initStats() {
+    if (this.stats) {
+      if (typeof this.devMode === 'object') {
+        this.statsContainer = this.devMode.statsContainer;
+      }
+      (this.statsContainer ?? document.body).appendChild(this.stats.dom);
+      this.stats.dom.classList.add('stats');
+      this.initGui();
     }
   }
 }

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -156,7 +156,7 @@ export class WebGLPreview {
   private devMode?: boolean | DevModeOptions = false;
   private _lastRenderTime = 0;
   private _wireframe = false;
-  private stats?: Stats = this.devMode ? new Stats() : undefined;
+  private stats?: Stats;
   private statsContainer?: HTMLElement;
   private devGui?: DevGUI;
 
@@ -182,6 +182,7 @@ export class WebGLPreview {
     this.renderTubes = opts.renderTubes ?? this.renderTubes;
     this.extrusionWidth = opts.extrusionWidth ?? this.extrusionWidth;
     this.devMode = opts.devMode ?? this.devMode;
+    this.stats = this.devMode ? new Stats() : undefined;
 
     if (opts.extrusionColor !== undefined) {
       this.extrusionColor = opts.extrusionColor;

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -156,7 +156,7 @@ export class WebGLPreview {
   private devMode?: boolean | DevModeOptions = true;
   private _lastRenderTime = 0;
   private _wireframe = false;
-  private stats: Stats = new Stats();
+  private stats: Stats = this.devMode ? new Stats() : undefined;
   private devGui?: DevGUI;
 
   constructor(opts: GCodePreviewOptions) {
@@ -245,7 +245,7 @@ export class WebGLPreview {
 
     if (opts.allowDragNDrop) this._enableDropHandler();
 
-    if (this.devMode) {
+    if (this.stats) {
       document.body.appendChild(this.stats.dom);
       this.initGui();
     }

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -153,7 +153,7 @@ export class WebGLPreview {
   private _toolColors: Record<number, Color> = {};
 
   // debug
-  private devMode?: boolean | DevModeOptions = true;
+  private devMode?: boolean | DevModeOptions = false;
   private _lastRenderTime = 0;
   private _wireframe = false;
   private stats?: Stats = this.devMode ? new Stats() : undefined;


### PR DESCRIPTION
changes 

- Adds `opts.devMode.statsContainer`, for passing an html element that will be the container for the stats object.
- Adds the classname `stats` to facilitate styling.
- Only instantiate the stats object when devMode is active

fixes #176 