### PR TITLE
Run actions on v3.x branch

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -6,6 +6,7 @@ name: Deploy to Firebase Hosting on merge
   push:
     branches:
       - develop
+      - v3.x
 jobs:
   build_and_deploy:
 

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -5,7 +5,9 @@ name: Deploy to Firebase Hosting on PR
 
 on:
   pull_request:
-    branches: [ develop ]
+    branches:
+      - develop
+      - v3.x
 
 jobs:
   build_and_preview:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -5,9 +5,15 @@ name: Runs All Unit tests
 
 on:
   push:
-    branches: [develop, releases]
+    branches:
+      - develop
+      - releases
+      - v3.x
   pull_request:
-    branches: [develop, releases]
+    branches:
+      - develop
+      - releases
+      - v3.x
 
 jobs:
   build:


### PR DESCRIPTION
I created a `v3.x` branch as a target for pull requests part of the development of the new version.

Github actions has to be enabled for pull requests aimed at that branch in order to run tests and deploy staging versions of the demo. 