### PR TITLE
Implement G21 (targeted on v3.x branch)

### DIFF
--- a/src/__tests__/interpreter.ts
+++ b/src/__tests__/interpreter.ts
@@ -197,6 +197,16 @@ test('.G20 sets the units to inches', () => {
   expect(job.state.units).toEqual('in');
 });
 
+test('.G21 sets the units to millimeters', () => {
+  const command = new GCodeCommand('G21', 'g21', {});
+  const interpreter = new Interpreter();
+  const job = new Job();
+
+  interpreter.G21(command, job);
+
+  expect(job.state.units).toEqual('mm');
+});
+
 test('.t0 sets the tool to 0', () => {
   const command = new GCodeCommand('T0', 't0', {});
   const interpreter = new Interpreter();

--- a/src/gcode-parser.ts
+++ b/src/gcode-parser.ts
@@ -62,6 +62,7 @@ export enum Code {
   G2 = 'G2',
   G3 = 'G3',
   G20 = 'G20',
+  G21 = 'G21',
   T0 = 'T0',
   T1 = 'T1',
   T2 = 'T2',
@@ -98,6 +99,8 @@ export class GCodeCommand {
         return Code.G3;
       case 'g20':
         return Code.G20;
+      case 'g21':
+        return Code.G21;
       case 't0':
         return Code.T0;
       case 't1':

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -134,6 +134,10 @@ export class Interpreter {
     job.state.units = 'in';
   }
 
+  G21(command: GCodeCommand, job: Job): void {
+    job.state.units = 'mm';
+  }
+
   T0(command: GCodeCommand, job: Job): void {
     job.state.tool = 0;
   }


### PR DESCRIPTION
Addresses https://github.com/remcoder/gcode-preview/issues/179

Implementing G21, which sets the units to mm

This was split out of https://github.com/remcoder/gcode-preview/pull/211
It has to be merged first.

With the new interpreter, this is a demonstration of how easy it is to support and test a new command implementation.