### PR TITLE
Implement G28 (targeted on v3.x branch)

### DIFF
--- a/src/__tests__/interpreter.ts
+++ b/src/__tests__/interpreter.ts
@@ -207,6 +207,20 @@ test('.G21 sets the units to millimeters', () => {
   expect(job.state.units).toEqual('mm');
 });
 
+test('.g28 moves the state to the origin', () => {
+  const command = new GCodeCommand('G28', 'g28', {});
+  const interpreter = new Interpreter();
+  const job = new Job();
+  job.state.x = 3;
+  job.state.y = 4;
+
+  interpreter.G28(command, job);
+
+  expect(job.state.x).toEqual(0);
+  expect(job.state.y).toEqual(0);
+  expect(job.state.z).toEqual(0);
+});
+
 test('.t0 sets the tool to 0', () => {
   const command = new GCodeCommand('T0', 't0', {});
   const interpreter = new Interpreter();

--- a/src/gcode-parser.ts
+++ b/src/gcode-parser.ts
@@ -63,6 +63,7 @@ export enum Code {
   G3 = 'G3',
   G20 = 'G20',
   G21 = 'G21',
+  G28 = 'G28',
   T0 = 'T0',
   T1 = 'T1',
   T2 = 'T2',
@@ -101,6 +102,8 @@ export class GCodeCommand {
         return Code.G20;
       case 'g21':
         return Code.G21;
+      case 'g28':
+        return Code.G28;
       case 't0':
         return Code.T0;
       case 't1':

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -138,6 +138,12 @@ export class Interpreter {
     job.state.units = 'mm';
   }
 
+  G28(command: GCodeCommand, job: Job): void {
+    job.state.x = 0;
+    job.state.y = 0;
+    job.state.z = 0;
+  }
+
   T0(command: GCodeCommand, job: Job): void {
     job.state.tool = 0;
   }


### PR DESCRIPTION
Addresses https://github.com/remcoder/gcode-preview/issues/179

Implementing G28, which homes the tool.

This was split out of https://github.com/remcoder/gcode-preview/pull/211
It has to be merged first.