### PR TITLE
Improve the paths subsets of jobs

### DIFF
--- a/demo/js/app.js
+++ b/demo/js/app.js
@@ -70,11 +70,11 @@ export const app = (window.app = createApp({
       const { thumbnails } = parser.metadata;
 
       thumbnail.value = thumbnails['220x124']?.src;
-      layerCount.value = job.layers()?.length;
+      layerCount.value = job.layers?.length;
       const colors = extrusionColor instanceof Array ? extrusionColor : [extrusionColor];
       const currentSettings = {
-        maxLayer: job.layers()?.length,
-        endLayer: job.layers()?.length,
+        maxLayer: job.layers?.length,
+        endLayer: job.layers?.length,
         singleLayerMode,
         renderTravel,
         travelColor: '#' + travelColor.getHexString(),
@@ -93,7 +93,7 @@ export const app = (window.app = createApp({
       };
 
       Object.assign(settings.value, currentSettings);
-      preview.endLayer = job.layers()?.length;
+      preview.endLayer = job.layers?.length;
     };
 
     const loadGCodeFromServer = async (filename) => {
@@ -121,12 +121,12 @@ export const app = (window.app = createApp({
     const render = async () => {
       debounce(async () => {
         if (loadProgressive) {
-          if (preview.job.layers() === null) {
+          if (preview.job.layers === null) {
             console.warn('Job is not planar');
             preview.render();
             return;
           }
-          await preview.renderAnimated(Math.ceil(preview.job.layers().length / 60));
+          await preview.renderAnimated(Math.ceil(preview.job.layers?.length / 60));
         } else {
           preview.render();
         }

--- a/src/__tests__/interpreter.ts
+++ b/src/__tests__/interpreter.ts
@@ -74,14 +74,15 @@ test('.G0 starts a path if the job has none', () => {
 
   const job = interpreter.execute([command]);
 
-  expect(job.paths.length).toEqual(1);
-  expect(job.paths[0].vertices.length).toEqual(6);
-  expect(job.paths[0].vertices[0]).toEqual(0);
-  expect(job.paths[0].vertices[1]).toEqual(0);
-  expect(job.paths[0].vertices[2]).toEqual(0);
-  expect(job.paths[0].vertices[3]).toEqual(1);
-  expect(job.paths[0].vertices[4]).toEqual(2);
-  expect(job.paths[0].vertices[5]).toEqual(0);
+  expect(job.paths.length).toEqual(0);
+  expect(job.inprogressPath).not.toBeNull();
+  expect(job.inprogressPath?.vertices.length).toEqual(6);
+  expect(job.inprogressPath?.vertices[0]).toEqual(0);
+  expect(job.inprogressPath?.vertices[1]).toEqual(0);
+  expect(job.inprogressPath?.vertices[2]).toEqual(0);
+  expect(job.inprogressPath?.vertices[3]).toEqual(1);
+  expect(job.inprogressPath?.vertices[4]).toEqual(2);
+  expect(job.inprogressPath?.vertices[5]).toEqual(0);
 });
 
 test('.G0 starts a path if the job has none, starting at the job current state', () => {
@@ -94,12 +95,12 @@ test('.G0 starts a path if the job has none, starting at the job current state',
 
   interpreter.execute([command], job);
 
-  expect(job.paths.length).toEqual(1);
-  expect(job.paths[0].vertices.length).toEqual(6);
-  expect(job.paths[0].vertices[0]).toEqual(3);
-  expect(job.paths[0].vertices[1]).toEqual(4);
-  expect(job.paths[0].vertices[2]).toEqual(0);
-  expect(job.paths[0].tool).toEqual(5);
+  expect(job.paths.length).toEqual(0);
+  expect(job.inprogressPath?.vertices.length).toEqual(6);
+  expect(job.inprogressPath?.vertices[0]).toEqual(3);
+  expect(job.inprogressPath?.vertices[1]).toEqual(4);
+  expect(job.inprogressPath?.vertices[2]).toEqual(0);
+  expect(job.inprogressPath?.tool).toEqual(5);
 });
 
 test('.G0 continues the path if the job has one', () => {
@@ -113,11 +114,11 @@ test('.G0 continues the path if the job has one', () => {
 
   interpreter.G0(command2, job);
 
-  expect(job.paths.length).toEqual(1);
-  expect(job.paths[0].vertices.length).toEqual(9);
-  expect(job.paths[0].vertices[6]).toEqual(3);
-  expect(job.paths[0].vertices[7]).toEqual(4);
-  expect(job.paths[0].vertices[8]).toEqual(5);
+  expect(job.paths.length).toEqual(0);
+  expect(job.inprogressPath?.vertices.length).toEqual(9);
+  expect(job.inprogressPath?.vertices[6]).toEqual(3);
+  expect(job.inprogressPath?.vertices[7]).toEqual(4);
+  expect(job.inprogressPath?.vertices[8]).toEqual(5);
 });
 
 test(".G0 assigns the travel type if there's no extrusion", () => {
@@ -127,8 +128,8 @@ test(".G0 assigns the travel type if there's no extrusion", () => {
 
   interpreter.G0(command, job);
 
-  expect(job.paths.length).toEqual(1);
-  expect(job.paths[0].travelType).toEqual(PathType.Travel);
+  expect(job.paths.length).toEqual(0);
+  expect(job.inprogressPath?.travelType).toEqual(PathType.Travel);
 });
 
 test(".G0 assigns the extrusion type if there's extrusion", () => {
@@ -138,8 +139,8 @@ test(".G0 assigns the extrusion type if there's extrusion", () => {
 
   interpreter.G0(command, job);
 
-  expect(job.paths.length).toEqual(1);
-  expect(job.paths[0].travelType).toEqual('Extrusion');
+  expect(job.paths.length).toEqual(0);
+  expect(job.inprogressPath?.travelType).toEqual('Extrusion');
 });
 
 test('.G0 assigns the travel type if the extrusion is a retraction', () => {
@@ -149,8 +150,19 @@ test('.G0 assigns the travel type if the extrusion is a retraction', () => {
 
   interpreter.G0(command, job);
 
-  expect(job.paths.length).toEqual(1);
-  expect(job.paths[0].travelType).toEqual('Travel');
+  expect(job.paths.length).toEqual(0);
+  expect(job.inprogressPath?.travelType).toEqual('Travel');
+});
+
+test('.G0 assigns the travel type if the extrusion is a retraction', () => {
+  const command = new GCodeCommand('G0 E-2', 'g0', { e: -2 });
+  const interpreter = new Interpreter();
+  const job = new Job();
+
+  interpreter.G0(command, job);
+
+  expect(job.paths.length).toEqual(0);
+  expect(job.inprogressPath?.travelType).toEqual('Travel');
 });
 
 test('.G0 starts a new path if the travel type changes from Travel to Extrusion', () => {
@@ -162,9 +174,8 @@ test('.G0 starts a new path if the travel type changes from Travel to Extrusion'
 
   interpreter.G0(command2, job);
 
-  expect(job.paths.length).toEqual(2);
-  expect(job.paths[0].travelType).toEqual('Travel');
-  expect(job.paths[1].travelType).toEqual('Extrusion');
+  expect(job.paths.length).toEqual(1);
+  expect(job.inprogressPath?.travelType).toEqual('Extrusion');
 });
 
 test('.G0 starts a new path if the travel type changes from Extrusion to Travel', () => {
@@ -176,9 +187,8 @@ test('.G0 starts a new path if the travel type changes from Extrusion to Travel'
 
   interpreter.G0(command2, job);
 
-  expect(job.paths.length).toEqual(2);
-  expect(job.paths[0].travelType).toEqual('Extrusion');
-  expect(job.paths[1].travelType).toEqual('Travel');
+  expect(job.paths.length).toEqual(1);
+  expect(job.inprogressPath?.travelType).toEqual('Travel');
 });
 
 test('.G1 is an alias to .G0', () => {

--- a/src/__tests__/job.ts
+++ b/src/__tests__/job.ts
@@ -121,7 +121,7 @@ describe('.extrusions', () => {
     append_path(job, PathType.Travel, [5, 6, 0, 5, 6, 0]);
     append_path(job, PathType.Extrusion, [1, 2, 0, 5, 6, 0]);
 
-    const extrusions = job.extrusions();
+    const extrusions = job.extrusions;
 
     expect(extrusions).not.toBeNull();
     expect(extrusions).toBeInstanceOf(Array);
@@ -141,7 +141,7 @@ describe('.travels', () => {
     append_path(job, PathType.Extrusion, [1, 2, 0, 5, 6, 0]);
     append_path(job, PathType.Travel, [5, 6, 0, 5, 6, 0]);
 
-    const travels = job.travels();
+    const travels = job.travels;
 
     expect(travels).not.toBeNull();
     expect(travels).toBeInstanceOf(Array);
@@ -155,5 +155,5 @@ describe('.travels', () => {
 function append_path(job, travelType, vertices) {
   const path = new Path(travelType, 0.6, 0.2, job.state.tool);
   path.vertices = vertices;
-  job.paths.push(path);
+  job.addPath(path);
 }

--- a/src/__tests__/job.ts
+++ b/src/__tests__/job.ts
@@ -12,8 +12,14 @@ describe('.isPlanar', () => {
   test('returns true if all extrusions are on the same plane', () => {
     const job = new Job();
 
-    append_path(job, PathType.Extrusion, [0, 0, 0, 1, 2, 0]);
-    append_path(job, PathType.Extrusion, [1, 2, 0, 5, 6, 0]);
+    append_path(job, PathType.Extrusion, [
+      [0, 0, 0],
+      [1, 2, 0]
+    ]);
+    append_path(job, PathType.Extrusion, [
+      [1, 2, 0],
+      [5, 6, 0]
+    ]);
 
     expect(job.isPlanar()).toEqual(true);
   });
@@ -21,8 +27,14 @@ describe('.isPlanar', () => {
   test('returns false if any extrusions are on a different plane', () => {
     const job = new Job();
 
-    append_path(job, PathType.Extrusion, [0, 0, 0, 1, 2, 0]);
-    append_path(job, PathType.Extrusion, [1, 2, 0, 5, 6, 1]);
+    append_path(job, PathType.Extrusion, [
+      [0, 0, 0],
+      [1, 2, 0]
+    ]);
+    append_path(job, PathType.Extrusion, [
+      [1, 2, 0],
+      [5, 6, 1]
+    ]);
 
     expect(job.isPlanar()).toEqual(false);
   });
@@ -30,9 +42,19 @@ describe('.isPlanar', () => {
   test('ignores travel paths', () => {
     const job = new Job();
 
-    append_path(job, PathType.Extrusion, [0, 0, 0, 1, 2, 0]);
-    append_path(job, PathType.Travel, [5, 6, 0, 5, 6, 1, 1, 2, 0]);
-    append_path(job, PathType.Extrusion, [1, 2, 0, 5, 6, 0]);
+    append_path(job, PathType.Extrusion, [
+      [0, 0, 0],
+      [1, 2, 0]
+    ]);
+    append_path(job, PathType.Travel, [
+      [5, 6, 0],
+      [5, 6, 1],
+      [1, 2, 0]
+    ]);
+    append_path(job, PathType.Extrusion, [
+      [1, 2, 0],
+      [5, 6, 0]
+    ]);
 
     expect(job.isPlanar()).toEqual(true);
   });
@@ -42,8 +64,14 @@ describe('.layers', () => {
   test('returns null if the job is not planar', () => {
     const job = new Job();
 
-    append_path(job, PathType.Extrusion, [0, 0, 0, 1, 2, 0]);
-    append_path(job, PathType.Extrusion, [5, 6, 0, 5, 6, 1]);
+    append_path(job, PathType.Extrusion, [
+      [0, 0, 0],
+      [1, 2, 0]
+    ]);
+    append_path(job, PathType.Extrusion, [
+      [5, 6, 0],
+      [5, 6, 1]
+    ]);
 
     expect(job.layers).toEqual(null);
   });
@@ -51,8 +79,14 @@ describe('.layers', () => {
   test('paths without z changes are on the same layer', () => {
     const job = new Job();
 
-    append_path(job, PathType.Extrusion, [0, 0, 0, 1, 2, 0]);
-    append_path(job, PathType.Travel, [5, 6, 0, 5, 6, 0]);
+    append_path(job, PathType.Extrusion, [
+      [0, 0, 0],
+      [1, 2, 0]
+    ]);
+    append_path(job, PathType.Travel, [
+      [5, 6, 0],
+      [5, 6, 0]
+    ]);
 
     const layers = job.layers;
 
@@ -65,8 +99,14 @@ describe('.layers', () => {
   test('travel paths moving z create a new layer', () => {
     const job = new Job();
 
-    append_path(job, PathType.Extrusion, [0, 0, 0, 1, 2, 0]);
-    append_path(job, PathType.Travel, [5, 6, 0, 5, 6, 1]);
+    append_path(job, PathType.Extrusion, [
+      [0, 0, 0],
+      [1, 2, 0]
+    ]);
+    append_path(job, PathType.Travel, [
+      [5, 6, 0],
+      [5, 6, 1]
+    ]);
 
     const layers = job.layers;
 
@@ -80,10 +120,22 @@ describe('.layers', () => {
   test('multiple travels in a row are on the same layer', () => {
     const job = new Job();
 
-    append_path(job, PathType.Extrusion, [0, 0, 0, 1, 2, 0]);
-    append_path(job, PathType.Travel, [5, 6, 0, 5, 6, 2]);
-    append_path(job, PathType.Travel, [5, 6, 2, 5, 6, 0]);
-    append_path(job, PathType.Travel, [5, 6, 0, 5, 6, 2]);
+    append_path(job, PathType.Extrusion, [
+      [0, 0, 0],
+      [1, 2, 0]
+    ]);
+    append_path(job, PathType.Travel, [
+      [5, 6, 0],
+      [5, 6, 2]
+    ]);
+    append_path(job, PathType.Travel, [
+      [5, 6, 2],
+      [5, 6, 0]
+    ]);
+    append_path(job, PathType.Travel, [
+      [5, 6, 0],
+      [5, 6, 2]
+    ]);
 
     const layers = job.layers;
 
@@ -97,11 +149,26 @@ describe('.layers', () => {
   test('extrusions after travels are on the same layer', () => {
     const job = new Job();
 
-    append_path(job, PathType.Extrusion, [0, 0, 0, 1, 2, 0]);
-    append_path(job, PathType.Travel, [5, 6, 0, 5, 6, 2]);
-    append_path(job, PathType.Travel, [5, 6, 2, 5, 6, 0]);
-    append_path(job, PathType.Travel, [5, 6, 0, 5, 6, 2]);
-    append_path(job, PathType.Extrusion, [5, 6, 2, 5, 6, 2]);
+    append_path(job, PathType.Extrusion, [
+      [0, 0, 0],
+      [1, 2, 0]
+    ]);
+    append_path(job, PathType.Travel, [
+      [5, 6, 0],
+      [5, 6, 2]
+    ]);
+    append_path(job, PathType.Travel, [
+      [5, 6, 2],
+      [5, 6, 0]
+    ]);
+    append_path(job, PathType.Travel, [
+      [5, 6, 0],
+      [5, 6, 2]
+    ]);
+    append_path(job, PathType.Extrusion, [
+      [5, 6, 2],
+      [5, 6, 2]
+    ]);
 
     const layers = job.layers;
 
@@ -117,9 +184,18 @@ describe('.extrusions', () => {
   test('returns all extrusion paths', () => {
     const job = new Job();
 
-    append_path(job, PathType.Extrusion, [0, 0, 0, 1, 2, 0]);
-    append_path(job, PathType.Travel, [5, 6, 0, 5, 6, 0]);
-    append_path(job, PathType.Extrusion, [1, 2, 0, 5, 6, 0]);
+    append_path(job, PathType.Extrusion, [
+      [0, 0, 0],
+      [1, 2, 0]
+    ]);
+    append_path(job, PathType.Travel, [
+      [5, 6, 0],
+      [5, 6, 0]
+    ]);
+    append_path(job, PathType.Extrusion, [
+      [1, 2, 0],
+      [5, 6, 0]
+    ]);
 
     const extrusions = job.extrusions;
 
@@ -136,10 +212,22 @@ describe('.travels', () => {
   test('returns all travel paths', () => {
     const job = new Job();
 
-    append_path(job, PathType.Extrusion, [0, 0, 0, 1, 2, 0]);
-    append_path(job, PathType.Travel, [5, 6, 0, 5, 6, 0]);
-    append_path(job, PathType.Extrusion, [1, 2, 0, 5, 6, 0]);
-    append_path(job, PathType.Travel, [5, 6, 0, 5, 6, 0]);
+    append_path(job, PathType.Extrusion, [
+      [0, 0, 0],
+      [1, 2, 0]
+    ]);
+    append_path(job, PathType.Travel, [
+      [5, 6, 0],
+      [5, 6, 0]
+    ]);
+    append_path(job, PathType.Extrusion, [
+      [1, 2, 0],
+      [5, 6, 0]
+    ]);
+    append_path(job, PathType.Travel, [
+      [5, 6, 0],
+      [5, 6, 0]
+    ]);
 
     const travels = job.travels;
 
@@ -152,8 +240,8 @@ describe('.travels', () => {
   });
 });
 
-function append_path(job, travelType, vertices) {
+function append_path(job, travelType, points) {
   const path = new Path(travelType, 0.6, 0.2, job.state.tool);
-  path.vertices = vertices;
+  points.forEach((point: [number, number, number]) => path.addPoint(...point));
   job.addPath(path);
 }

--- a/src/__tests__/job.ts
+++ b/src/__tests__/job.ts
@@ -45,7 +45,7 @@ describe('.layers', () => {
     append_path(job, PathType.Extrusion, [0, 0, 0, 1, 2, 0]);
     append_path(job, PathType.Extrusion, [5, 6, 0, 5, 6, 1]);
 
-    expect(job.layers()).toEqual(null);
+    expect(job.layers).toEqual(null);
   });
 
   test('paths without z changes are on the same layer', () => {
@@ -54,7 +54,7 @@ describe('.layers', () => {
     append_path(job, PathType.Extrusion, [0, 0, 0, 1, 2, 0]);
     append_path(job, PathType.Travel, [5, 6, 0, 5, 6, 0]);
 
-    const layers = job.layers();
+    const layers = job.layers;
 
     expect(layers).not.toBeNull();
     expect(layers).toBeInstanceOf(Array);
@@ -68,7 +68,7 @@ describe('.layers', () => {
     append_path(job, PathType.Extrusion, [0, 0, 0, 1, 2, 0]);
     append_path(job, PathType.Travel, [5, 6, 0, 5, 6, 1]);
 
-    const layers = job.layers();
+    const layers = job.layers;
 
     expect(layers).not.toBeNull();
     expect(layers).toBeInstanceOf(Array);
@@ -85,7 +85,7 @@ describe('.layers', () => {
     append_path(job, PathType.Travel, [5, 6, 2, 5, 6, 0]);
     append_path(job, PathType.Travel, [5, 6, 0, 5, 6, 2]);
 
-    const layers = job.layers();
+    const layers = job.layers;
 
     expect(layers).not.toBeNull();
     expect(layers).toBeInstanceOf(Array);
@@ -103,7 +103,7 @@ describe('.layers', () => {
     append_path(job, PathType.Travel, [5, 6, 0, 5, 6, 2]);
     append_path(job, PathType.Extrusion, [5, 6, 2, 5, 6, 2]);
 
-    const layers = job.layers();
+    const layers = job.layers;
 
     expect(layers).not.toBeNull();
     expect(layers).toBeInstanceOf(Array);

--- a/src/__tests__/path.ts
+++ b/src/__tests__/path.ts
@@ -67,7 +67,8 @@ test('.path returns an array of Vector3', () => {
 test('.geometry returns an ExtrusionGeometry from the path', () => {
   const path = new Path(PathType.Travel, undefined, undefined, undefined);
 
-  path.vertices = [0, 0, 0, 1, 2, 3];
+  path.addPoint(0, 0, 0);
+  path.addPoint(1, 2, 3);
 
   const result = path.geometry() as ExtrusionGeometry;
 
@@ -80,7 +81,8 @@ test('.geometry returns an ExtrusionGeometry from the path', () => {
 test('.geometry returns an ExtrusionGeometry with the path extrusion width', () => {
   const path = new Path(PathType.Travel, 9, undefined, undefined);
 
-  path.vertices = [0, 0, 0, 1, 2, 3];
+  path.addPoint(0, 0, 0);
+  path.addPoint(1, 2, 3);
 
   const result = path.geometry() as ExtrusionGeometry;
 
@@ -90,7 +92,8 @@ test('.geometry returns an ExtrusionGeometry with the path extrusion width', () 
 test('.geometry returns an ExtrusionGeometry with the path line height', () => {
   const path = new Path(PathType.Travel, undefined, 5, undefined);
 
-  path.vertices = [0, 0, 0, 1, 2, 3];
+  path.addPoint(0, 0, 0);
+  path.addPoint(1, 2, 3);
 
   const result = path.geometry() as ExtrusionGeometry;
 
@@ -109,7 +112,8 @@ test('.geometry returns an empty BufferGeometry if there are less than 3 vertice
 test('.line returns a BufferGeometry from the path', () => {
   const path = new Path(PathType.Travel, undefined, undefined, undefined);
 
-  path.vertices = [0, 0, 0, 1, 2, 3];
+  path.addPoint(0, 0, 0);
+  path.addPoint(1, 2, 3);
 
   const result = path.line();
 

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -171,7 +171,7 @@ export class Interpreter {
 
   private breakPath(job: Job, newType: PathType): Path {
     const lastPath = new Path(newType, 0.6, 0.2, job.state.tool);
-    job.paths.push(lastPath);
+    job.addPath(lastPath);
     lastPath.addPoint(job.state.x, job.state.y, job.state.z);
     return lastPath;
   }

--- a/src/job.ts
+++ b/src/job.ts
@@ -62,7 +62,9 @@ export class Job {
       try {
         indexer.sortIn(path);
       } catch (e) {
-        this.layersPaths = null;
+        if (e.message === "Non-planar paths can't be indexed by layer") {
+          this.layersPaths = null;
+        }
         const i = this.indexers.indexOf(indexer);
         this.indexers.splice(i, 1);
       }

--- a/src/job.ts
+++ b/src/job.ts
@@ -18,10 +18,27 @@ export class State {
 export class Job {
   paths: Path[];
   state: State;
+  private travelPaths: Path[] = [];
+  private extrusionPaths: Path[] = [];
+  private layersPaths: Path[][] = [];
+  private indexers: Indexer[] = [new TravelTypeIndexer({ travel: this.travelPaths, extrusion: this.extrusionPaths })];
 
   constructor(state?: State) {
     this.paths = [];
     this.state = state || State.initial;
+  }
+
+  get extrusions(): Path[] {
+    return this.extrusionPaths;
+  }
+
+  get travels(): Path[] {
+    return this.travelPaths;
+  }
+
+  addPath(path: Path): void {
+    this.paths.push(path);
+    this.indexPath(path);
   }
 
   isPlanar(): boolean {
@@ -61,11 +78,33 @@ export class Job {
     return layers;
   }
 
-  extrusions(): Path[] {
-    return this.paths.filter((path) => path.travelType === PathType.Extrusion);
+  private indexPath(path: Path): void {
+    this.indexers.forEach((indexer) => indexer.sortIn(path));
+  }
+}
+
+class Indexer {
+  protected indexes: Record<string, Path[]>;
+  constructor(_indexes: Record<string, Path[]>) {
+    this.indexes = _indexes;
+  }
+  sortIn(path: Path): boolean {
+    path;
+    throw new Error('Method not implemented.');
+  }
+}
+
+class TravelTypeIndexer extends Indexer {
+  constructor(indexes: Record<string, Path[]>) {
+    super(indexes);
   }
 
-  travels(): Path[] {
-    return this.paths.filter((path) => path.travelType === PathType.Travel);
+  sortIn(path: Path): boolean {
+    if (path.travelType === PathType.Extrusion) {
+      this.indexes.extrusion.push(path);
+    } else {
+      this.indexes.travel.push(path);
+    }
+    return true;
   }
 }

--- a/src/path.ts
+++ b/src/path.ts
@@ -9,31 +9,35 @@ export enum PathType {
 
 export class Path {
   public travelType: PathType;
-  public vertices: number[];
-  extrusionWidth: number;
-  lineHeight: number;
-  tool: number;
+  public extrusionWidth: number;
+  public lineHeight: number;
+  public tool: number;
+  private _vertices: number[];
 
   constructor(travelType: PathType, extrusionWidth = 0.6, lineHeight = 0.2, tool = 0) {
     this.travelType = travelType;
-    this.vertices = [];
+    this._vertices = [];
     this.extrusionWidth = extrusionWidth;
     this.lineHeight = lineHeight;
     this.tool = tool;
   }
 
+  get vertices(): number[] {
+    return this._vertices;
+  }
+
   addPoint(x: number, y: number, z: number): void {
-    this.vertices.push(x, y, z);
+    this._vertices.push(x, y, z);
   }
 
   checkLineContinuity(x: number, y: number, z: number): boolean {
-    if (this.vertices.length < 3) {
+    if (this._vertices.length < 3) {
       return false;
     }
 
-    const lastX = this.vertices[this.vertices.length - 3];
-    const lastY = this.vertices[this.vertices.length - 2];
-    const lastZ = this.vertices[this.vertices.length - 1];
+    const lastX = this._vertices[this._vertices.length - 3];
+    const lastY = this._vertices[this._vertices.length - 2];
+    const lastZ = this._vertices[this._vertices.length - 1];
 
     return x === lastX && y === lastY && z === lastZ;
   }
@@ -41,14 +45,14 @@ export class Path {
   path(): Vector3[] {
     const path: Vector3[] = [];
 
-    for (let i = 0; i < this.vertices.length; i += 3) {
-      path.push(new Vector3(this.vertices[i], this.vertices[i + 1], this.vertices[i + 2]));
+    for (let i = 0; i < this._vertices.length; i += 3) {
+      path.push(new Vector3(this._vertices[i], this._vertices[i + 1], this._vertices[i + 2]));
     }
     return path;
   }
 
   geometry(): BufferGeometry {
-    if (this.vertices.length < 3) {
+    if (this._vertices.length < 3) {
       return new BufferGeometry();
     }
 
@@ -57,5 +61,9 @@ export class Path {
 
   line(): BufferGeometry {
     return new BufferGeometry().setFromPoints(this.path());
+  }
+
+  hasVerticalMoves(): boolean {
+    return this.vertices.some((_, i, arr) => i % 3 === 2 && arr[i] !== arr[2]);
   }
 }

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -322,7 +322,7 @@ export class WebGLPreview {
 
     this.renderLayerIndex = 0;
 
-    if (this.job.layers() === null) {
+    if (this.job.layers === null) {
       console.warn('Job is not planar');
       this.render();
       return;
@@ -334,7 +334,7 @@ export class WebGLPreview {
   private renderFrameLoop(layerCount: number): Promise<void> {
     return new Promise((resolve) => {
       const loop = () => {
-        if (this.renderLayerIndex >= this.job.layers().length - 1) {
+        if (this.renderLayerIndex >= this.job.layers?.length - 1) {
           resolve();
         } else {
           this.renderFrame(layerCount);
@@ -348,11 +348,8 @@ export class WebGLPreview {
   private renderFrame(layerCount: number): void {
     this.group = this.createGroup('layer' + this.renderLayerIndex);
 
-    const endIndex = Math.min(this.renderLayerIndex + layerCount, this.job.layers().length - 1);
-    const pathsToRender = this.job
-      .layers()
-      .slice(this.renderLayerIndex, endIndex)
-      .flatMap((l) => l);
+    const endIndex = Math.min(this.renderLayerIndex + layerCount, this.job.layers?.length - 1);
+    const pathsToRender = this.job.layers?.slice(this.renderLayerIndex, endIndex)?.flatMap((l) => l);
 
     this.renderGeometries(pathsToRender.filter((path) => path.travelType === 'Extrusion'));
     this.renderLines(

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -433,7 +433,7 @@ export class WebGLPreview {
     });
   }
 
-  private renderLines(travels = this.job.travels(), extrusions = this.job.extrusions()): void {
+  private renderLines(travels = this.job.travels, extrusions = this.job.extrusions): void {
     if (this.renderTravel) {
       const material = new LineBasicMaterial({ color: this._travelColor, linewidth: this.lineWidth });
       this.disposables.push(material);
@@ -467,7 +467,7 @@ export class WebGLPreview {
     }
   }
 
-  private renderGeometries(paths = this.job.extrusions()): void {
+  private renderGeometries(paths = this.job.extrusions): void {
     if (Object.keys(this._geometries).length === 0 && this.renderTubes) {
       let color: number;
       paths.forEach((path) => {


### PR DESCRIPTION
Follow up to https://github.com/remcoder/gcode-preview/pull/211

`layers`, `extrusions` and `travels` are now more performant!

Instead of filtering the whole `paths` array each time, the job uses indexers to categorize paths as they are added. They are then accessed as readily available data without additional logic.

To implement indexes, logic to have paths "in progress" and finish them had to be implemented to only index when the path is finished.

Paths are indexed as they are added to a job, which is less expensive than filtering the array on the spot. Jobs have a set of default indexers. They can be added or removed for the different rendering modes. It paves the way to https://github.com/remcoder/gcode-preview/issues/121 as we'll have to index for the different types of extrusions. It is also a possible implementation for https://github.com/remcoder/gcode-preview/pull/183.

When an indexer throws an error, it is interpreted as not applicable for a specific job. It is removed from the list of indexers for the rest of the commands. I am pretty happy about that design; it stops some code and conditions from running for the rest of the list of paths we are iterating on. 

Adding/removing indexers will have a significant impact later when we have many of them. Other logic related to stats and calculations may follow a similar design and benefit from being composed. If they become expensive, we'll only use what is needed.

Next PR would be to bring back the tolerance logic inside the indexer that was omitted in https://github.com/remcoder/gcode-preview/pull/211

Note that this branch was not rebased after https://github.com/remcoder/gcode-preview/pull/215, making progressive rendering a bit funky. With the fix, you'll notice the smoothness is back.
