### PR TITLE
Don't recalculate Geometries at each render

### DIFF
--- a/src/path.ts
+++ b/src/path.ts
@@ -13,6 +13,8 @@ export class Path {
   extrusionWidth: number;
   lineHeight: number;
   tool: number;
+  _geometry: BufferGeometry | undefined;
+  _line: BufferGeometry | undefined;
 
   constructor(travelType: PathType, extrusionWidth = 0.6, lineHeight = 0.2, tool = 0) {
     this.travelType = travelType;
@@ -52,10 +54,10 @@ export class Path {
       return new BufferGeometry();
     }
 
-    return new ExtrusionGeometry(this.path(), this.extrusionWidth, this.lineHeight, 4);
+    return (this._geometry ||= new ExtrusionGeometry(this.path(), this.extrusionWidth, this.lineHeight, 4));
   }
 
   line(): BufferGeometry {
-    return new BufferGeometry().setFromPoints(this.path());
+    return (this._line ||= new BufferGeometry().setFromPoints(this.path()));
   }
 }


### PR DESCRIPTION
With every re-render, geometries are recalculated even though paths have not changed. Memoizing the geometry building method helps with that. 

It has no perceptible performance impact the initial render, even with progressive rendering. However, the next renders are significantly faster and we can notice.

There are downsides of memoizing as it requires more memory. It should be an option exposed, because it really depends on the use case. If the same model has to be re-rendered multiple times, memoization is great. If only one render is needed per gcode file, cache should be off. I am not sure what the default should be. 

What do you think? Should this PR include the option? What should be the default?