### PR TITLE
Bring back the tolerance logic

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -15,11 +15,6 @@ export class State {
   }
 }
 
-type JobOptions = {
-  state?: State;
-  minLayerThreshold?: number;
-};
-
 export class Job {
   paths: Path[];
   state: State;
@@ -29,7 +24,7 @@ export class Job {
   private indexers: Indexer[];
   inprogressPath: Path | undefined;
 
-  constructor(opts: JobOptions = {}) {
+  constructor(opts: { state?: State; minLayerThreshold?: number } = {}) {
     this.paths = [];
     this.state = opts.state || State.initial;
     this.layersPaths = [[]];

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -39,6 +39,7 @@ export type GCodePreviewOptions = {
   lineWidth?: number;
   lineHeight?: number;
   nonTravelMoves?: string[];
+  minLayerThreshold?: number;
   renderExtrusion?: boolean;
   renderTravel?: boolean;
   startLayer?: number;
@@ -61,6 +62,7 @@ export type GCodePreviewOptions = {
 };
 
 export class WebGLPreview {
+  minLayerThreshold: number;
   /**
    * @deprecated Please use the `canvas` param instead.
    */
@@ -89,8 +91,8 @@ export class WebGLPreview {
   nonTravelmoves: string[] = [];
   disableGradient = false;
 
+  job: Job;
   interpreter = new Interpreter();
-  job = new Job();
   parser = new Parser();
 
   // rendering
@@ -118,6 +120,8 @@ export class WebGLPreview {
   private devGui?: DevGUI;
 
   constructor(opts: GCodePreviewOptions) {
+    this.minLayerThreshold = opts.minLayerThreshold ?? this.minLayerThreshold;
+    this.job = new Job({ minLayerThreshold: this.minLayerThreshold });
     this.scene = new Scene();
     this.scene.background = this._backgroundColor;
     if (opts.backgroundColor !== undefined) {
@@ -366,7 +370,7 @@ export class WebGLPreview {
   clear(): void {
     this.resetState();
     this.parser = new Parser();
-    this.job = new Job();
+    this.job = new Job({ minLayerThreshold: this.minLayerThreshold });
   }
 
   // reset processing state


### PR DESCRIPTION
Part of https://github.com/remcoder/gcode-preview/issues/221

Bringing back layer tolerance for z-axis movements and added configuration options for minimum layer threshold.

- Added back `minLayerThreshold` option to the lib options
- The option is passed to the `Job`
- The job uses it to instantiate a layer indexer with tolerance
- The layer indexer has a default tolerance of `0.05` (same as before)
- The indexer uses that tolerance to split the layers based on z changes