### PR TITLE
Wire up `renderExtrusion` and `renderTubes`

### DIFF
--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -465,6 +465,10 @@ export class WebGLPreview {
   }
 
   private renderGeometries(paths = this.job.extrusions): void {
+    if (!this.renderExtrusion || !this.renderTubes) {
+      return;
+    }
+
     if (Object.keys(this._geometries).length === 0 && this.renderTubes) {
       let color: number;
       paths.forEach((path) => {


### PR DESCRIPTION
Part of https://github.com/remcoder/gcode-preview/issues/221

As part of the v3.x refactor, several options were omitted in order to reimplement incrementally to keep the PR shorter.

This PR is bringing back `renderExtrusion` and `renderTubes`.