### PR TITLE
Remove the Code enum

### DIFF
--- a/src/__tests__/interpreter.ts
+++ b/src/__tests__/interpreter.ts
@@ -112,7 +112,7 @@ test('.G0 continues the path if the job has one', () => {
   job.state.z = 5;
   interpreter.execute([command1], job);
 
-  interpreter.G0(command2, job);
+  interpreter.g0(command2, job);
 
   expect(job.paths.length).toEqual(0);
   expect(job.inprogressPath?.vertices.length).toEqual(9);
@@ -126,7 +126,7 @@ test(".G0 assigns the travel type if there's no extrusion", () => {
   const interpreter = new Interpreter();
   const job = new Job();
 
-  interpreter.G0(command, job);
+  interpreter.g0(command, job);
 
   expect(job.paths.length).toEqual(0);
   expect(job.inprogressPath?.travelType).toEqual(PathType.Travel);
@@ -137,7 +137,7 @@ test(".G0 assigns the extrusion type if there's extrusion", () => {
   const interpreter = new Interpreter();
   const job = new Job();
 
-  interpreter.G0(command, job);
+  interpreter.g0(command, job);
 
   expect(job.paths.length).toEqual(0);
   expect(job.inprogressPath?.travelType).toEqual('Extrusion');
@@ -148,7 +148,7 @@ test('.G0 assigns the travel type if the extrusion is a retraction', () => {
   const interpreter = new Interpreter();
   const job = new Job();
 
-  interpreter.G0(command, job);
+  interpreter.g0(command, job);
 
   expect(job.paths.length).toEqual(0);
   expect(job.inprogressPath?.travelType).toEqual('Travel');
@@ -159,7 +159,7 @@ test('.G0 assigns the travel type if the extrusion is a retraction', () => {
   const interpreter = new Interpreter();
   const job = new Job();
 
-  interpreter.G0(command, job);
+  interpreter.g0(command, job);
 
   expect(job.paths.length).toEqual(0);
   expect(job.inprogressPath?.travelType).toEqual('Travel');
@@ -172,7 +172,7 @@ test('.G0 starts a new path if the travel type changes from Travel to Extrusion'
   const job = new Job();
   interpreter.execute([command1], job);
 
-  interpreter.G0(command2, job);
+  interpreter.g0(command2, job);
 
   expect(job.paths.length).toEqual(1);
   expect(job.inprogressPath?.travelType).toEqual('Extrusion');
@@ -185,7 +185,7 @@ test('.G0 starts a new path if the travel type changes from Extrusion to Travel'
   const job = new Job();
   interpreter.execute([command1], job);
 
-  interpreter.G0(command2, job);
+  interpreter.g0(command2, job);
 
   expect(job.paths.length).toEqual(1);
   expect(job.inprogressPath?.travelType).toEqual('Travel');
@@ -194,7 +194,7 @@ test('.G0 starts a new path if the travel type changes from Extrusion to Travel'
 test('.G1 is an alias to .G0', () => {
   const interpreter = new Interpreter();
 
-  expect(interpreter.G1).toEqual(interpreter.G0);
+  expect(interpreter.g1).toEqual(interpreter.g0);
 });
 
 test('.G20 sets the units to inches', () => {
@@ -202,7 +202,7 @@ test('.G20 sets the units to inches', () => {
   const interpreter = new Interpreter();
   const job = new Job();
 
-  interpreter.G20(command, job);
+  interpreter.g20(command, job);
 
   expect(job.state.units).toEqual('in');
 });
@@ -212,7 +212,7 @@ test('.G21 sets the units to millimeters', () => {
   const interpreter = new Interpreter();
   const job = new Job();
 
-  interpreter.G21(command, job);
+  interpreter.g21(command, job);
 
   expect(job.state.units).toEqual('mm');
 });
@@ -224,7 +224,7 @@ test('.g28 moves the state to the origin', () => {
   job.state.x = 3;
   job.state.y = 4;
 
-  interpreter.G28(command, job);
+  interpreter.g28(command, job);
 
   expect(job.state.x).toEqual(0);
   expect(job.state.y).toEqual(0);
@@ -237,7 +237,7 @@ test('.t0 sets the tool to 0', () => {
   const job = new Job();
   job.state.tool = 3;
 
-  interpreter.T0(command, job);
+  interpreter.t0(command, job);
 
   expect(job.state.tool).toEqual(0);
 });
@@ -248,7 +248,7 @@ test('.t1 sets the tool to 1', () => {
   const job = new Job();
   job.state.tool = 3;
 
-  interpreter.T1(command, job);
+  interpreter.t1(command, job);
 
   expect(job.state.tool).toEqual(1);
 });
@@ -259,7 +259,7 @@ test('.t2 sets the tool to 2', () => {
   const job = new Job();
   job.state.tool = 3;
 
-  interpreter.T2(command, job);
+  interpreter.t2(command, job);
 
   expect(job.state.tool).toEqual(2);
 });
@@ -270,7 +270,7 @@ test('.t3 sets the tool to 3', () => {
   const job = new Job();
   job.state.tool = 3;
 
-  interpreter.T3(command, job);
+  interpreter.t3(command, job);
 
   expect(job.state.tool).toEqual(3);
 });
@@ -281,7 +281,7 @@ test('.t4 sets the tool to 4', () => {
   const job = new Job();
   job.state.tool = 3;
 
-  interpreter.T4(command, job);
+  interpreter.t4(command, job);
 
   expect(job.state.tool).toEqual(4);
 });
@@ -292,7 +292,7 @@ test('.t5 sets the tool to 5', () => {
   const job = new Job();
   job.state.tool = 3;
 
-  interpreter.T5(command, job);
+  interpreter.t5(command, job);
 
   expect(job.state.tool).toEqual(5);
 });
@@ -303,7 +303,7 @@ test('.t6 sets the tool to 6', () => {
   const job = new Job();
   job.state.tool = 3;
 
-  interpreter.T6(command, job);
+  interpreter.t6(command, job);
 
   expect(job.state.tool).toEqual(6);
 });
@@ -314,7 +314,7 @@ test('.t7 sets the tool to 7', () => {
   const job = new Job();
   job.state.tool = 3;
 
-  interpreter.T7(command, job);
+  interpreter.t7(command, job);
 
   expect(job.state.tool).toEqual(7);
 });

--- a/src/gcode-parser.ts
+++ b/src/gcode-parser.ts
@@ -56,74 +56,13 @@ type singleLetter =
   | 'Z';
 type CommandParams = { [key in singleLetter]?: number };
 
-export enum Code {
-  G0 = 'G0',
-  G1 = 'G1',
-  G2 = 'G2',
-  G3 = 'G3',
-  G20 = 'G20',
-  G21 = 'G21',
-  G28 = 'G28',
-  T0 = 'T0',
-  T1 = 'T1',
-  T2 = 'T2',
-  T3 = 'T3',
-  T4 = 'T4',
-  T5 = 'T5',
-  T6 = 'T6',
-  T7 = 'T7'
-}
 export class GCodeCommand {
-  public code?: Code;
   constructor(
     public src: string,
     public gcode: string,
     public params: CommandParams,
     public comment?: string
-  ) {
-    this.code = this.match(gcode);
-  }
-
-  match(gcode: string): Code {
-    switch (gcode) {
-      case 'g0':
-      case 'g00':
-        return Code.G0;
-      case 'g1':
-      case 'g01':
-        return Code.G1;
-      case 'g2':
-      case 'g02':
-        return Code.G2;
-      case 'g3':
-      case 'g03':
-        return Code.G3;
-      case 'g20':
-        return Code.G20;
-      case 'g21':
-        return Code.G21;
-      case 'g28':
-        return Code.G28;
-      case 't0':
-        return Code.T0;
-      case 't1':
-        return Code.T1;
-      case 't2':
-        return Code.T2;
-      case 't3':
-        return Code.T3;
-      case 't4':
-        return Code.T4;
-      case 't5':
-        return Code.T5;
-      case 't6':
-        return Code.T6;
-      case 't7':
-        return Code.T7;
-      default:
-        return undefined;
-    }
-  }
+  ) {}
 }
 
 type Metadata = { thumbnails: Record<string, Thumbnail> };
@@ -163,7 +102,7 @@ export class Parser {
       .slice(1)
       .map((s) => s.trim());
 
-    const gcode = !parts.length ? '' : `${parts[0]?.toLowerCase()}${parts[1]}`;
+    const gcode = !parts.length ? '' : `${parts[0]?.toLowerCase()}${Number(parts[1])}`;
     const params = this.parseParams(parts.slice(2));
     return new GCodeCommand(line, gcode, params, comment);
   }

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -1,19 +1,24 @@
 import { Path, PathType } from './path';
-import { Code, GCodeCommand } from './gcode-parser';
+import { GCodeCommand } from './gcode-parser';
 import { Job } from './job';
 
 export class Interpreter {
+  // eslint-disable-next-line no-unused-vars
+  [key: string]: (...args: unknown[]) => unknown;
   execute(commands: GCodeCommand[], job = new Job()): Job {
     commands.forEach((command) => {
-      if (command.code !== undefined) {
-        this[command.code](command, job);
+      if (command.gcode !== undefined) {
+        if (this[command.gcode] === undefined) {
+          return;
+        }
+        this[command.gcode](command, job);
       }
     });
 
     return job;
   }
 
-  G0(command: GCodeCommand, job: Job): void {
+  g0(command: GCodeCommand, job: Job): void {
     const { x, y, z, e } = command.params;
     const { state } = job;
 
@@ -31,14 +36,14 @@ export class Interpreter {
     currentPath.addPoint(state.x, state.y, state.z);
   }
 
-  G1 = this.G0;
+  g1 = this.g0;
 
-  G2(command: GCodeCommand, job: Job): void {
+  g2(command: GCodeCommand, job: Job): void {
     const { x, y, z, e } = command.params;
     let { i, j, r } = command.params;
     const { state } = job;
 
-    const cw = command.code === Code.G2;
+    const cw = command.gcode === 'g2';
     let currentPath = job.inprogressPath;
     const pathType = e ? PathType.Extrusion : PathType.Travel;
 
@@ -128,44 +133,44 @@ export class Interpreter {
     currentPath.addPoint(state.x, state.y, state.z);
   }
 
-  G3 = this.G2;
+  g3 = this.g2;
 
-  G20(command: GCodeCommand, job: Job): void {
+  g20(command: GCodeCommand, job: Job): void {
     job.state.units = 'in';
   }
 
-  G21(command: GCodeCommand, job: Job): void {
+  g21(command: GCodeCommand, job: Job): void {
     job.state.units = 'mm';
   }
 
-  G28(command: GCodeCommand, job: Job): void {
+  g28(command: GCodeCommand, job: Job): void {
     job.state.x = 0;
     job.state.y = 0;
     job.state.z = 0;
   }
 
-  T0(command: GCodeCommand, job: Job): void {
+  t0(command: GCodeCommand, job: Job): void {
     job.state.tool = 0;
   }
-  T1(command: GCodeCommand, job: Job): void {
+  t1(command: GCodeCommand, job: Job): void {
     job.state.tool = 1;
   }
-  T2(command: GCodeCommand, job: Job): void {
+  t2(command: GCodeCommand, job: Job): void {
     job.state.tool = 2;
   }
-  T3(command: GCodeCommand, job: Job): void {
+  t3(command: GCodeCommand, job: Job): void {
     job.state.tool = 3;
   }
-  T4(command: GCodeCommand, job: Job): void {
+  t4(command: GCodeCommand, job: Job): void {
     job.state.tool = 4;
   }
-  T5(command: GCodeCommand, job: Job): void {
+  t5(command: GCodeCommand, job: Job): void {
     job.state.tool = 5;
   }
-  T6(command: GCodeCommand, job: Job): void {
+  t6(command: GCodeCommand, job: Job): void {
     job.state.tool = 6;
   }
-  T7(command: GCodeCommand, job: Job): void {
+  t7(command: GCodeCommand, job: Job): void {
     job.state.tool = 7;
   }
 


### PR DESCRIPTION
Follow-up to https://github.com/remcoder/gcode-preview/pull/211

The `Code` enum bothered me a lot. I figured how to make the interpreter work with a magic function without having to use an enum. I think Typescript did not complain in the previous implementation because enum values are the same type or subtype of the index method. I had to add an index signature to make it work with strings.

Now, to define a new gcode implementation there's only one file to touch (excluding tests). We only have to define the new method!