### PR TITLE
Use clipping to render layers with `startLayer` and `endLayer`

### DIFF
--- a/demo/js/app.js
+++ b/demo/js/app.js
@@ -196,9 +196,6 @@ export const app = (window.app = createApp({
       });
 
       watchEffect(() => {
-        preview.startLayer = +settings.value.startLayer;
-        preview.endLayer = +settings.value.endLayer;
-        preview.singleLayerMode = settings.value.singleLayerMode;
         preview.renderExtrusion = settings.value.renderExtrusion;
 
         preview.travelColor = settings.value.travelColor;
@@ -212,6 +209,12 @@ export const app = (window.app = createApp({
         preview.lastSegmentColor = settings.value.highlightLastSegment ? settings.value.lastSegmentColor : undefined;
 
         render();
+      });
+
+      watchEffect(() => {
+        preview.startLayer = +settings.value.startLayer;
+        preview.endLayer = +settings.value.endLayer;
+        preview.singleLayerMode = settings.value.singleLayerMode;
       });
     });
 

--- a/demo/js/app.js
+++ b/demo/js/app.js
@@ -9,7 +9,7 @@ const preferDarkMode = window.matchMedia('(prefers-color-scheme: dark)');
 const initialBackgroundColor = preferDarkMode.matches ? '#141414' : '#eee';
 const statsContainer = () => document.querySelector('.sidebar');
 
-const loadProgressive = false;
+const loadProgressive = true;
 let observer = null;
 let preview = null;
 
@@ -126,7 +126,7 @@ export const app = (window.app = createApp({
             preview.render();
             return;
           }
-          await preview.renderAnimated(Math.ceil(preview.countLayers / 60));
+          await preview.renderAnimated(2000);
         } else {
           preview.render();
         }

--- a/demo/js/app.js
+++ b/demo/js/app.js
@@ -9,7 +9,7 @@ const preferDarkMode = window.matchMedia('(prefers-color-scheme: dark)');
 const initialBackgroundColor = preferDarkMode.matches ? '#141414' : '#eee';
 const statsContainer = () => document.querySelector('.sidebar');
 
-const loadProgressive = true;
+const loadProgressive = false;
 let observer = null;
 let preview = null;
 

--- a/demo/js/app.js
+++ b/demo/js/app.js
@@ -9,7 +9,7 @@ const preferDarkMode = window.matchMedia('(prefers-color-scheme: dark)');
 const initialBackgroundColor = preferDarkMode.matches ? '#141414' : '#eee';
 const statsContainer = () => document.querySelector('.sidebar');
 
-const loadProgressive = false;
+const loadProgressive = true;
 let observer = null;
 let preview = null;
 

--- a/demo/js/presets.js
+++ b/demo/js/presets.js
@@ -14,7 +14,7 @@ export const presets = {
   mach3: {
     title: 'CNC tool path',
     file: 'gcodes/mach3.gcode',
-    lineWidth: 1,
+    lineWidth: 2,
     renderExtrusion: false,
     renderTravel: true,
     travelColor: '#00FF00',
@@ -62,7 +62,7 @@ export const presets = {
   'travel-moves': {
     title: 'Travel moves',
     file: 'gcodes/plant-sign.gcode',
-    lineWidth: 0,
+    lineWidth: 1,
     renderExtrusion: true,
     renderTubes: true,
     extrusionColor: ['#777777'],

--- a/demo/js/presets.js
+++ b/demo/js/presets.js
@@ -44,6 +44,7 @@ export const presets = {
     file: 'gcodes/vase.gcode',
     lineWidth: 0,
     lineHeight: 0.4,
+    minLayerThreshold: 0.6,
     renderExtrusion: true,
     renderTubes: true,
     extrusionColor: ['rgb(84,74,187)'],

--- a/src/__tests__/job.ts
+++ b/src/__tests__/job.ts
@@ -363,18 +363,6 @@ describe('.resumeLastPath', () => {
     expect(job.paths).toEqual([]);
   });
 
-  test('clears the in progress path', () => {
-    const job = new Job();
-    const path = new Path(PathType.Extrusion, 0.6, 0.2, 0);
-
-    path.addPoint(0, 0, 0);
-
-    job.inprogressPath = path;
-    job.resumeLastPath();
-
-    expect(job.inprogressPath).toBeUndefined();
-  });
-
   test('the path is removed from indexes to not appear twice', () => {
     const job = new Job();
 

--- a/src/__tests__/job.ts
+++ b/src/__tests__/job.ts
@@ -306,6 +306,32 @@ describe('.travels', () => {
   });
 });
 
+describe('.toolPaths', () => {
+  test('Extrusions using the same tool are indexed', () => {
+    const job = new Job();
+
+    append_path(job, PathType.Extrusion, [], 0);
+    append_path(job, PathType.Extrusion, [], 1);
+    append_path(job, PathType.Extrusion, [], 0);
+    append_path(job, PathType.Extrusion, [], 1);
+    append_path(job, PathType.Extrusion, [], 5);
+    append_path(job, PathType.Extrusion, [], 2);
+    append_path(job, PathType.Extrusion, [], 2);
+
+    const toolPaths = job.toolPaths;
+
+    expect(toolPaths).not.toBeNull();
+    expect(toolPaths).toBeInstanceOf(Array);
+    expect(toolPaths.length).toEqual(6);
+    expect(toolPaths[0].length).toEqual(2);
+    expect(toolPaths[1].length).toEqual(2);
+    expect(toolPaths[2].length).toEqual(2);
+    expect(toolPaths[3]).toBeUndefined();
+    expect(toolPaths[4]).toBeUndefined();
+    expect(toolPaths[5].length).toEqual(1);
+  });
+});
+
 describe('.addPath', () => {
   test('adds the path to the job', () => {
     const job = new Job();
@@ -401,8 +427,8 @@ describe('.resumeLastPath', () => {
   });
 });
 
-function append_path(job: Job, travelType, points: [number, number, number][]): Path {
-  const path = new Path(travelType, 0.6, 0.2, job.state.tool);
+function append_path(job: Job, travelType, points: [number, number, number][], tool: number = 0): Path {
+  const path = new Path(travelType, 0.6, 0.2, tool || job.state.tool);
   points.forEach((point: [number, number, number]) => path.addPoint(...point));
   job.addPath(path);
   return path;

--- a/src/__tests__/job.ts
+++ b/src/__tests__/job.ts
@@ -217,6 +217,33 @@ describe('.layers', () => {
     expect(layers[0].paths.length).toEqual(4);
     expect(layers[1].paths.length).toEqual(1);
   });
+
+  test('initial travels are on the same layer as the first extrusion', () => {
+    const job = new Job();
+
+    append_path(job, PathType.Travel, [
+      [5, 6, 0],
+      [5, 6, 0]
+    ]);
+    append_path(job, PathType.Travel, [
+      [5, 6, 2],
+      [5, 6, 0]
+    ]);
+    append_path(job, PathType.Travel, [
+      [5, 6, 0],
+      [5, 6, 2]
+    ]);
+    append_path(job, PathType.Extrusion, [
+      [5, 6, 2],
+      [5, 6, 2]
+    ]);
+
+    const layers = job.layers;
+
+    expect(layers).not.toBeNull();
+    expect(layers.length).toEqual(1);
+    expect(layers[0].paths.length).toEqual(4);
+  });
 });
 
 describe('.extrusions', () => {

--- a/src/extrusion-geometry.ts
+++ b/src/extrusion-geometry.ts
@@ -102,7 +102,6 @@ class ExtrusionGeometry extends BufferGeometry {
         vertex.x = P.x + lineWidth * normal.x * 0.5;
         vertex.y = P.y + lineWidth * normal.y * 0.5;
         vertex.z = P.z + lineHeight * normal.z * 0.5;
-        // vertices.push(vertex.x, vertex.y, vertex.z);
         vertices.push(vertex.x, vertex.y, vertex.z - lineHeight * 0.5);
       }
     }

--- a/src/extrusion-geometry.ts
+++ b/src/extrusion-geometry.ts
@@ -102,7 +102,8 @@ class ExtrusionGeometry extends BufferGeometry {
         vertex.x = P.x + lineWidth * normal.x * 0.5;
         vertex.y = P.y + lineWidth * normal.y * 0.5;
         vertex.z = P.z + lineHeight * normal.z * 0.5;
-        vertices.push(vertex.x, vertex.y, vertex.z);
+        // vertices.push(vertex.x, vertex.y, vertex.z);
+        vertices.push(vertex.x, vertex.y, vertex.z - lineHeight * 0.5);
       }
     }
 

--- a/src/job.ts
+++ b/src/job.ts
@@ -158,6 +158,7 @@ export class LayersIndexer extends Indexer {
     ) {
       throw new NonPlanarPathError();
     }
+
     if (this.indexes[this.indexes.length - 1] === undefined) {
       this.createLayer(path.vertices[2]);
     }

--- a/src/job.ts
+++ b/src/job.ts
@@ -163,7 +163,7 @@ export class LayersIndexer extends Indexer {
   sortIn(path: Path): void {
     if (
       path.travelType === PathType.Extrusion &&
-      path.vertices.some((_, i, arr) => i % 3 === 2 && Math.abs(arr[i] - arr[i - 3]) >= this.tolerance)
+      path.vertices.some((_, i, arr) => i > 3 && i % 3 === 2 && Math.abs(arr[i] - arr[i - 3]) > this.tolerance)
     ) {
       throw new NonPlanarPathError();
     }

--- a/src/job.ts
+++ b/src/job.ts
@@ -172,7 +172,10 @@ export class LayersIndexer extends Indexer {
       this.createLayer(path.vertices[2]);
     }
 
-    if (path.travelType === PathType.Extrusion) {
+    if (
+      path.travelType === PathType.Extrusion &&
+      this.lastLayer().paths.some((p) => p.travelType === PathType.Extrusion)
+    ) {
       if (path.vertices[2] - (this.lastLayer().z || 0) > this.tolerance) {
         this.createLayer(path.vertices[2]);
       }

--- a/src/job.ts
+++ b/src/job.ts
@@ -177,7 +177,7 @@ export class LayersIndexer extends Indexer {
 
   private createLayer(z: number): void {
     const layerNumber = this.indexes.length;
-    const height = z - this.lastLayer()?.z;
+    const height = z - (this.lastLayer()?.z || 0);
     this.indexes.push(new Layer(this.indexes.length, [], layerNumber, height, z));
   }
 }

--- a/src/job.ts
+++ b/src/job.ts
@@ -158,7 +158,6 @@ export class LayersIndexer extends Indexer {
     ) {
       throw new NonPlanarPathError();
     }
-
     if (this.indexes[this.indexes.length - 1] === undefined) {
       this.createLayer(path.vertices[2]);
     }

--- a/src/path.ts
+++ b/src/path.ts
@@ -66,7 +66,13 @@ export class Path {
   }
 
   line(): LineSegmentsGeometry {
-    return new LineSegmentsGeometry().setPositions(this.vertices);
+    const lineVertices = [];
+    for (let i = 0; i < this._vertices.length - 3; i += 3) {
+      lineVertices.push(this._vertices[i], this._vertices[i + 1], this._vertices[i + 2]);
+      lineVertices.push(this._vertices[i + 3], this._vertices[i + 4], this._vertices[i + 5]);
+    }
+
+    return new LineSegmentsGeometry().setPositions(lineVertices);
   }
 
   hasVerticalMoves(): boolean {

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -273,7 +273,9 @@ export class WebGLPreview {
   }
   set startLayer(value: number) {
     this._startLayer = value;
-    this.minPlane.constant = (value - 1) * 0.02;
+    if (this.countLayers > 0) {
+      this.minPlane.constant = -this.minPlane.normal.y * this.job.layers[value]?.z;
+    }
   }
 
   get endLayer(): number {
@@ -281,7 +283,10 @@ export class WebGLPreview {
   }
   set endLayer(value: number) {
     this._endLayer = value;
-    this.maxPlane.constant = (value + 2) * -0.02;
+    if (this.countLayers > 0) {
+      const layer = this.job.layers[value - 1];
+      this.maxPlane.constant = -this.maxPlane.normal.y * (layer?.z + layer.height);
+    }
   }
 
   /** @internal */

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -106,8 +106,8 @@ export class WebGLPreview {
   private animationFrameId?: number;
   private renderLayerIndex?: number;
   private _geometries: Record<number, BufferGeometry[]> = {};
-  private minPlane = new Plane(new Vector3(0, -1, 0), 0.6);
-  private maxPlane = new Plane(new Vector3(0, 1, 0), 0.1);
+  private minPlane = new Plane(new Vector3(0, 1, 0), 0.6);
+  private maxPlane = new Plane(new Vector3(0, -1, 0), 0.1);
   planeHelper = new PlaneHelper(this.minPlane, 200, 0xff0000);
   planeHelper2 = new PlaneHelper(this.maxPlane, 200, 0x00ff00);
 
@@ -187,10 +187,7 @@ export class WebGLPreview {
       const container = document.getElementById(this.targetId);
       if (!container) throw new Error('Unable to find element ' + this.targetId);
 
-      this.renderer = new WebGLRenderer({ preserveDrawingBuffer: true, antialias: true, alpha: true });
-      this.renderer.clippingPlanes = [this.minPlane, this.maxPlane];
-      this.renderer.localClippingEnabled = true;
-      this.renderer.autoClear = false;
+      this.renderer = new WebGLRenderer({ preserveDrawingBuffer: true });
       this.canvas = this.renderer.domElement;
 
       container.appendChild(this.canvas);
@@ -202,6 +199,7 @@ export class WebGLPreview {
       });
     }
 
+    this.renderer.localClippingEnabled = true;
     this.camera = new PerspectiveCamera(25, this.canvas.offsetWidth / this.canvas.offsetHeight, 10, 5000);
     this.camera.position.fromArray(this.initialCameraPosition);
     const fogFar = (this.camera as PerspectiveCamera).far;
@@ -326,11 +324,6 @@ export class WebGLPreview {
       this.scene.add(light);
       this.scene.add(dLight);
     }
-
-    this.planeHelper.visible = true;
-    this.planeHelper2.visible = true;
-    this.scene.add(this.planeHelper);
-    this.scene.add(this.planeHelper2);
   }
 
   private createGroup(name: string): Group {

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -26,7 +26,6 @@ import {
   MeshLambertMaterial,
   PerspectiveCamera,
   Plane,
-  PlaneHelper,
   PointLight,
   REVISION,
   Scene,
@@ -111,8 +110,6 @@ export class WebGLPreview {
   private renderPathIndex?: number;
   private minPlane = new Plane(new Vector3(0, 1, 0), 0.6);
   private maxPlane = new Plane(new Vector3(0, -1, 0), 0.1);
-  planeHelper = new PlaneHelper(this.minPlane, 200, 0xff0000);
-  planeHelper2 = new PlaneHelper(this.maxPlane, 200, 0x00ff00);
 
   // colors
   private _backgroundColor = new Color(0xe0e0e0);

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -272,7 +272,7 @@ export class WebGLPreview {
   set startLayer(value: number) {
     this._startLayer = value;
     if (this.countLayers > 0) {
-      if (value <= this.countLayers) {
+      if (value <= this.countLayers && value > 0) {
         const layer = this.job.layers[value - 1];
         this.minPlane.constant = -this.minPlane.normal.y * layer.z;
       } else {
@@ -290,7 +290,7 @@ export class WebGLPreview {
       this.startLayer = this._endLayer;
     }
     if (this.countLayers > 0) {
-      if (value <= this.countLayers) {
+      if (value <= this.countLayers && value > 0) {
         const layer = this.job.layers[value - 1];
         this.maxPlane.constant = -this.maxPlane.normal.y * layer.z;
       } else {
@@ -303,6 +303,8 @@ export class WebGLPreview {
     this._singleLayerMode = value;
     if (value) {
       this.startLayer = this.endLayer - 1;
+    } else {
+      this.startLayer = 1;
     }
   }
 

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -272,7 +272,13 @@ export class WebGLPreview {
   set startLayer(value: number) {
     this._startLayer = value;
     if (this.countLayers > 0) {
-      this.minPlane.constant = -this.minPlane.normal.y * this.job.layers[value]?.z;
+      if (value <= this.countLayers) {
+        const layer = this.job.layers[value - 1];
+        // The geometry should be changed to have it's center in the middle line height
+        this.minPlane.constant = -this.minPlane.normal.y * layer.z - layer.height * 0.5;
+      } else {
+        this.minPlane.constant = 0;
+      }
     }
   }
 
@@ -282,8 +288,12 @@ export class WebGLPreview {
   set endLayer(value: number) {
     this._endLayer = value;
     if (this.countLayers > 0) {
-      const layer = this.job.layers[value - 1];
-      this.maxPlane.constant = -this.maxPlane.normal.y * (layer?.z + layer.height);
+      if (value <= this.countLayers) {
+        const layer = this.job.layers[value - 1];
+        this.maxPlane.constant = -this.maxPlane.normal.y * layer.z + layer.height * 0.5;
+      } else {
+        this.maxPlane.constant = 0;
+      }
     }
   }
 

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -81,8 +81,8 @@ export class WebGLPreview {
   extrusionWidth?: number;
   lineWidth?: number;
   lineHeight?: number;
-  startLayer?: number;
-  endLayer?: number;
+  _startLayer?: number;
+  _endLayer?: number;
   singleLayerMode = false;
   buildVolume?: BuildVolume;
   initialCameraPosition = [-100, 400, 450];
@@ -106,8 +106,8 @@ export class WebGLPreview {
   private animationFrameId?: number;
   private renderLayerIndex?: number;
   private _geometries: Record<number, BufferGeometry[]> = {};
-  private minPlane = new Plane(new Vector3(0, 1, 0), 0.6);
-  private maxPlane = new Plane(new Vector3(0, -1, 0), 0.1);
+  private minPlane = new Plane(new Vector3(0, -1, 0), 0.6);
+  private maxPlane = new Plane(new Vector3(0, 1, 0), 0.1);
   planeHelper = new PlaneHelper(this.minPlane, 200, 0xff0000);
   planeHelper2 = new PlaneHelper(this.maxPlane, 200, 0x00ff00);
 
@@ -266,6 +266,22 @@ export class WebGLPreview {
 
   get countLayers(): number {
     return this.job.layers.length;
+  }
+
+  get startLayer(): number {
+    return this._startLayer;
+  }
+  set startLayer(value: number) {
+    this._startLayer = value;
+    this.minPlane.constant = (value - 1) * 0.02;
+  }
+
+  get endLayer(): number {
+    return this._endLayer;
+  }
+  set endLayer(value: number) {
+    this._endLayer = value;
+    this.maxPlane.constant = (value + 2) * -0.02;
   }
 
   /** @internal */
@@ -520,12 +536,8 @@ export class WebGLPreview {
   }
 
   private createBatchMesh(color: number): BatchedMesh {
-    // debugger;
     const geometries = this._geometries[color];
-    this.maxPlane.constant = (this.endLayer + 2) * 0.02;
-    this.minPlane.constant = (this.startLayer - 1) * -0.02;
 
-    console.log('clipping planes', this.maxPlane, this.minPlane);
     const material = new MeshLambertMaterial({
       color: color,
       wireframe: this._wireframe,

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -267,9 +267,6 @@ export class WebGLPreview {
   }
 
   get startLayer(): number {
-    if (this._singleLayerMode) {
-      this.startLayer = this.endLayer - 1;
-    }
     return this._startLayer;
   }
   set startLayer(value: number) {
@@ -277,8 +274,7 @@ export class WebGLPreview {
     if (this.countLayers > 0) {
       if (value <= this.countLayers) {
         const layer = this.job.layers[value - 1];
-        // The geometry should be changed to have it's center in the middle line height
-        this.minPlane.constant = -this.minPlane.normal.y * layer.z - layer.height * 0.5;
+        this.minPlane.constant = -this.minPlane.normal.y * layer.z;
       } else {
         this.minPlane.constant = 0;
       }
@@ -291,12 +287,12 @@ export class WebGLPreview {
   set endLayer(value: number) {
     this._endLayer = value;
     if (this._singleLayerMode) {
-      this.startLayer = this._endLayer - 1;
+      this.startLayer = this._endLayer;
     }
     if (this.countLayers > 0) {
       if (value <= this.countLayers) {
         const layer = this.job.layers[value - 1];
-        this.maxPlane.constant = -this.maxPlane.normal.y * layer.z + layer.height * 0.5;
+        this.maxPlane.constant = -this.maxPlane.normal.y * layer.z;
       } else {
         this.maxPlane.constant = 0;
       }
@@ -534,7 +530,7 @@ export class WebGLPreview {
 
     const batchedMesh = this.createBatchMesh(geometries, material);
     this.disposables.push(material);
-    this.disposables.push(batchedMesh);
+    // this.disposables.push(batchedMesh);
 
     this.group?.add(batchedMesh);
   }

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -86,7 +86,7 @@ export class WebGLPreview {
   lineHeight?: number;
   _startLayer?: number;
   _endLayer?: number;
-  singleLayerMode = false;
+  _singleLayerMode = false;
   buildVolume?: BuildVolume;
   initialCameraPosition = [-100, 400, 450];
   /**
@@ -267,6 +267,9 @@ export class WebGLPreview {
   }
 
   get startLayer(): number {
+    if (this._singleLayerMode) {
+      this.startLayer = this.endLayer - 1;
+    }
     return this._startLayer;
   }
   set startLayer(value: number) {
@@ -287,6 +290,9 @@ export class WebGLPreview {
   }
   set endLayer(value: number) {
     this._endLayer = value;
+    if (this._singleLayerMode) {
+      this.startLayer = this._endLayer - 1;
+    }
     if (this.countLayers > 0) {
       if (value <= this.countLayers) {
         const layer = this.job.layers[value - 1];
@@ -294,6 +300,13 @@ export class WebGLPreview {
       } else {
         this.maxPlane.constant = 0;
       }
+    }
+  }
+
+  set singleLayerMode(value: boolean) {
+    this._singleLayerMode = value;
+    if (value) {
+      this.startLayer = this.endLayer - 1;
     }
   }
 
@@ -404,7 +417,7 @@ export class WebGLPreview {
   private resetState(): void {
     this.startLayer = 1;
     this.endLayer = Infinity;
-    this.singleLayerMode = false;
+    this._singleLayerMode = false;
     this.devGui?.reset();
   }
 


### PR DESCRIPTION
Part of https://github.com/remcoder/gcode-preview/issues/221

This PR ended up needing more changes than I initially anticipated, but it's leaving the files in a better state than when I started. 

The first implementation of clipping turned out to be easy to add. It became complex after needing to batch lines together as well to have a single material with the clipping planes.

Progressive rendering is always a forcing function for good implementations. You'll notice how clean the rendering methods turned out! All lines and tube use some sort of batching per color, and batches can be build progressively. The difference with how it's implemented. Instead of using layers, it uses subsets of paths.

### Todo
- [x] Implement for lines
- [x] Implement single layer mode
~- [ ] Implement a non-planar version~ The API assumes layers. Non-planar jobs need to use the tolerance in order to split into layers that are usable. option: https://github.com/remcoder/gcode-preview/issues/241
- [x] ~Use clipping for~ repair the progressive rendering mode
- [x] Fix the tube geometry to be positioned on top of the z position
- [x] Add tests
- [x] Remove the plane helpers