### PR TITLE
Disable preserveDrawingBuffer

### DIFF
--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -126,6 +126,7 @@ export class WebGLPreview {
   private stats?: Stats;
   private statsContainer?: HTMLElement;
   private devGui?: DevGUI;
+  private preserveDrawingBuffer = false;
 
   constructor(opts: GCodePreviewOptions) {
     this.minLayerThreshold = opts.minLayerThreshold ?? this.minLayerThreshold;
@@ -188,7 +189,7 @@ export class WebGLPreview {
       const container = document.getElementById(this.targetId);
       if (!container) throw new Error('Unable to find element ' + this.targetId);
 
-      this.renderer = new WebGLRenderer({ preserveDrawingBuffer: true });
+      this.renderer = new WebGLRenderer({ preserveDrawingBuffer: this.preserveDrawingBuffer });
       this.canvas = this.renderer.domElement;
 
       container.appendChild(this.canvas);
@@ -196,7 +197,7 @@ export class WebGLPreview {
       this.canvas = opts.canvas;
       this.renderer = new WebGLRenderer({
         canvas: this.canvas,
-        preserveDrawingBuffer: true
+        preserveDrawingBuffer: this.preserveDrawingBuffer
       });
     }
 


### PR DESCRIPTION
fixes #254 

tl;dr this fixes a render glitch on weak devices by disabling `preserveDrawingBuffer`.

What seemed to happen, **on some mobile devices**, is that subsequent calls to `renderer.render` didn't always render a complete model and every pass the result was different. (although it seemed to oscillate between a few states but in a random pattern)

btw this is the render call from threejs itself, and the issue is about what happens after the geometry has been built completely.

I tried to give the render call more room by switching from rAF to a timeout of 300ms or even 5000ms. This reduced the problem but not entirely. Performance profiling didn't show tasks in the 3000ms range. js and gpu were below 300ms per render call (this is an old phone mind you).

Eventually I tried to disable the flag `preserveDrawingBuffer` which, surprisingly, seems to fix the issue 😄 

This flag was set a long while back to allow making a snapshot of the canvas. For now this isn't a priority and the render glitch is a bigger problem I think.

