### PR TITLE
Fix drag and drop

### DIFF
--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -577,10 +577,15 @@ export class WebGLPreview {
       const maxFullLine = str.slice(0, idxNewLine);
 
       // parse increments but don't render yet
-      this.parser.parseGCode(tail + maxFullLine);
+      const { commands } = this.parser.parseGCode(tail + maxFullLine);
+
+      // we'll execute the commands immediately, for now
+      this.interpreter.execute(commands, this.job);
+      
       tail = str.slice(idxNewLine);
     } while (!result.done);
     console.debug('read from stream', size);
+    this.render();
   }
 
   private initGui() {

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -581,7 +581,7 @@ export class WebGLPreview {
 
       // we'll execute the commands immediately, for now
       this.interpreter.execute(commands, this.job);
-      
+
       tail = str.slice(idxNewLine);
     } while (!result.done);
     console.debug('read from stream', size);


### PR DESCRIPTION
fixes #253 

This fixes the _readableStream method with respect to the new architecture: the parsed gcode now needs to be executed by the interpreter and then rendered. This PR implements those steps for the _readableStream method in in principle but without any further optimizations at this point. 