### PR TITLE
Update layer logic

### DIFF
--- a/src/__tests__/job.ts
+++ b/src/__tests__/job.ts
@@ -52,17 +52,6 @@ describe('.isPlanar', () => {
     expect(job.isPlanar).toEqual(false);
   });
 
-  test('if any extrusion path has a delta Z that exceeds the default tolerance', () => {
-    const job = new Job();
-
-    append_path(job, PathType.Extrusion, [
-      [1, 2, 0],
-      [5, 6, 1]
-    ]);
-
-    expect(job.isPlanar).toEqual(false);
-  });
-
   test('ignores travel paths', () => {
     const job = new Job();
 

--- a/src/__tests__/job.ts
+++ b/src/__tests__/job.ts
@@ -85,7 +85,6 @@ describe('.isPlanar', () => {
 });
 
 describe('.layers', () => {
-
   test('returns empty list if no paths are present', () => {
     const job = new Job();
 
@@ -101,7 +100,7 @@ describe('.layers', () => {
     ]);
 
     expect(job.layers).toEqual([]);
-  });  
+  });
 
   test('returns empty list if the job is not planar', () => {
     const job = new Job();
@@ -334,7 +333,7 @@ describe('.layers', () => {
     expect(layers[0].z).toEqual(2);
   });
 
-   test('layer z must equal extrusion path z', () => {
+  test('layer z must equal extrusion path z', () => {
     const job = new Job();
 
     append_path(job, PathType.Extrusion, [
@@ -353,7 +352,6 @@ describe('.layers', () => {
     expect(layers.length).toEqual(1);
     expect(layers[0].z).toEqual(2);
   });
-
 
   test('layer z must equal path z, for second layer', () => {
     const job = new Job();

--- a/src/__tests__/job.ts
+++ b/src/__tests__/job.ts
@@ -11,7 +11,7 @@ test('it has an initial state', () => {
 });
 
 describe('.isPlanar', () => {
-  test('returns true if all extrusions are on the same plane', () => {
+  test('if all extrusions are on the same plane (Z=0)', () => {
     const job = new Job();
 
     append_path(job, PathType.Extrusion, [
@@ -23,22 +23,44 @@ describe('.isPlanar', () => {
       [5, 6, 0]
     ]);
 
-    expect(job.isPlanar()).toEqual(true);
+    expect(job.isPlanar).toEqual(true);
   });
 
-  test('returns false if any extrusions are on a different plane', () => {
+  test('if all extrusions are on the same plane (Z=1)', () => {
     const job = new Job();
 
     append_path(job, PathType.Extrusion, [
-      [0, 0, 0],
-      [1, 2, 0]
+      [0, 0, 1],
+      [1, 2, 1]
     ]);
+    append_path(job, PathType.Extrusion, [
+      [1, 2, 1],
+      [5, 6, 1]
+    ]);
+
+    expect(job.isPlanar).toEqual(true);
+  });
+
+  test('if any extrusion path has a Z value that exceeds the default tolerance', () => {
+    const job = new Job();
+
     append_path(job, PathType.Extrusion, [
       [1, 2, 0],
       [5, 6, 1]
     ]);
 
-    expect(job.isPlanar()).toEqual(false);
+    expect(job.isPlanar).toEqual(false);
+  });
+
+  test('if any extrusion path has a delta Z that exceeds the default tolerance', () => {
+    const job = new Job();
+
+    append_path(job, PathType.Extrusion, [
+      [1, 2, 0],
+      [5, 6, 1]
+    ]);
+
+    expect(job.isPlanar).toEqual(false);
   });
 
   test('ignores travel paths', () => {
@@ -58,12 +80,12 @@ describe('.isPlanar', () => {
       [5, 6, 0]
     ]);
 
-    expect(job.isPlanar()).toEqual(true);
+    expect(job.isPlanar).toEqual(true);
   });
 });
 
 describe('.layers', () => {
-  test('returns null if the job is not planar', () => {
+  test('returns empty list if the job is not planar', () => {
     const job = new Job();
 
     append_path(job, PathType.Extrusion, [
@@ -78,14 +100,14 @@ describe('.layers', () => {
     expect(job.layers).toEqual([]);
   });
 
-  test('paths without z changes are on the same layer', () => {
+  test('extrusions with same Z value are on the same layer', () => {
     const job = new Job();
 
     append_path(job, PathType.Extrusion, [
       [0, 0, 0],
       [1, 2, 0]
     ]);
-    append_path(job, PathType.Travel, [
+    append_path(job, PathType.Extrusion, [
       [5, 6, 0],
       [5, 6, 0]
     ]);
@@ -119,7 +141,7 @@ describe('.layers', () => {
     expect(layers[1].paths.length).toEqual(1);
   });
 
-  test('travel paths moving z under the default tolerance are on the same layer', () => {
+  test('travel with a z component is still on the same layer', () => {
     const job = new Job();
 
     append_path(job, PathType.Extrusion, [
@@ -128,7 +150,7 @@ describe('.layers', () => {
     ]);
     append_path(job, PathType.Travel, [
       [5, 6, 0],
-      [5, 6, LayersIndexer.DEFAULT_TOLERANCE - 0.01]
+      [5, 6, 42]
     ]);
 
     const layers = job.layers;
@@ -207,6 +229,38 @@ describe('.layers', () => {
       [5, 6, 2]
     ]);
     append_path(job, PathType.Extrusion, [
+      [5, 6, 0],
+      [5, 6, 0]
+    ]);
+
+    const layers = job.layers;
+
+    expect(layers).not.toBeNull();
+    expect(layers).toBeInstanceOf(Array);
+    expect(layers.length).toEqual(1);
+    expect(layers[0].paths.length).toEqual(5);
+  });
+
+  test('extrusions with a new Z value after travels are on a new layer', () => {
+    const job = new Job();
+
+    append_path(job, PathType.Extrusion, [
+      [0, 0, 0],
+      [1, 2, 0]
+    ]);
+    append_path(job, PathType.Travel, [
+      [5, 6, 0],
+      [5, 6, 2]
+    ]);
+    append_path(job, PathType.Travel, [
+      [5, 6, 2],
+      [5, 6, 0]
+    ]);
+    append_path(job, PathType.Travel, [
+      [5, 6, 0],
+      [5, 6, 2]
+    ]);
+    append_path(job, PathType.Extrusion, [
       [5, 6, 2],
       [5, 6, 2]
     ]);
@@ -220,7 +274,7 @@ describe('.layers', () => {
     expect(layers[1].paths.length).toEqual(1);
   });
 
-  test('initial travels are on the same layer as the first extrusion', () => {
+  test('initial travels are on the same layer as the first extrusion, regardless of Z height', () => {
     const job = new Job();
 
     append_path(job, PathType.Travel, [

--- a/src/__tests__/job.ts
+++ b/src/__tests__/job.ts
@@ -104,6 +104,7 @@ describe('.layers', () => {
     ]);
 
     expect(job.layers).toEqual([]);
+    expect(job.isPlanar).toEqual(false);
   });
 
   test('extrusions with same Z value are on the same layer', () => {

--- a/src/__tests__/job.ts
+++ b/src/__tests__/job.ts
@@ -174,7 +174,7 @@ describe('.layers', () => {
       [0, 0, 0],
       [1, 2, 0]
     ]);
-    append_path(job, PathType.Travel, [
+    append_path(job, PathType.Extrusion, [
       [5, 6, 0],
       [5, 6, 0.09]
     ]);

--- a/src/__tests__/job.ts
+++ b/src/__tests__/job.ts
@@ -300,6 +300,61 @@ describe('.layers', () => {
     expect(layers.length).toEqual(1);
     expect(layers[0].paths.length).toEqual(4);
   });
+
+  test('layer z must equal path z', () => {
+    const job = new Job();
+
+    append_path(job, PathType.Extrusion, [
+      [5, 6, 2],
+      [5, 6, 2]
+    ]);
+
+    const layers = job.layers;
+
+    expect(layers).not.toBeNull();
+    expect(layers.length).toEqual(1);
+    expect(layers[0].z).toEqual(2);
+  });
+
+   test('layer z must equal extrusion path z', () => {
+    const job = new Job();
+
+    append_path(job, PathType.Extrusion, [
+      [5, 6, 2],
+      [5, 6, 2]
+    ]);
+
+    append_path(job, PathType.Travel, [
+      [5, 6, 4],
+      [5, 6, 4]
+    ]);
+
+    const layers = job.layers;
+
+    expect(layers).not.toBeNull();
+    expect(layers.length).toEqual(1);
+    expect(layers[0].z).toEqual(2);
+  });
+
+
+  test('layer z must equal path z, for second layer', () => {
+    const job = new Job();
+
+    append_path(job, PathType.Extrusion, [
+      [5, 6, 2],
+      [5, 6, 2]
+    ]);
+    append_path(job, PathType.Extrusion, [
+      [5, 6, 4],
+      [5, 6, 4]
+    ]);
+
+    const layers = job.layers;
+
+    expect(layers).not.toBeNull();
+    expect(layers.length).toEqual(2);
+    expect(layers[1].z).toEqual(4);
+  });
 });
 
 describe('.extrusions', () => {

--- a/src/__tests__/job.ts
+++ b/src/__tests__/job.ts
@@ -85,6 +85,24 @@ describe('.isPlanar', () => {
 });
 
 describe('.layers', () => {
+
+  test('returns empty list if no paths are present', () => {
+    const job = new Job();
+
+    expect(job.layers).toEqual([]);
+  });
+
+  test('returns empty list if no extrusion is present', () => {
+    const job = new Job();
+
+    append_path(job, PathType.Travel, [
+      [0, 0, 0],
+      [1, 2, 0]
+    ]);
+
+    expect(job.layers).toEqual([]);
+  });  
+
   test('returns empty list if the job is not planar', () => {
     const job = new Job();
 
@@ -274,7 +292,7 @@ describe('.layers', () => {
     expect(layers[1].paths.length).toEqual(1);
   });
 
-  test('initial travels are on the same layer as the first extrusion, regardless of Z height', () => {
+  test('travel paths before the first extrusion are not indexed', () => {
     const job = new Job();
 
     append_path(job, PathType.Travel, [
@@ -298,7 +316,7 @@ describe('.layers', () => {
 
     expect(layers).not.toBeNull();
     expect(layers.length).toEqual(1);
-    expect(layers[0].paths.length).toEqual(4);
+    expect(layers[0].paths.length).toEqual(1);
   });
 
   test('layer z must equal path z', () => {

--- a/src/indexers.ts
+++ b/src/indexers.ts
@@ -104,33 +104,27 @@ export class LayersIndexer extends Indexer {
       throw new NonPlanarPathError();
     }
 
-    if (this.indexes[this.indexes.length - 1] === undefined) {
-      // Create the first layer at the current Z height (which is always 0 bc the gcode origin is at 0,0,0)
-      this.createLayer(0);
-    }
+    // new layers are only created when extruding
+    if (path.travelType === PathType.Extrusion)
+    {
+      const newZ = path.vertices[2];
+      const lastZ = this.lastLayer?.z;
 
-    if (
-      path.travelType === PathType.Extrusion &&
-      this.lastLayer().paths.some((p) => p.travelType === PathType.Extrusion)
-    ) {
-      if (path.vertices[2] - (this.lastLayer().z || 0) > this.tolerance) {
-        this.createLayer(path.vertices[2]);
+      // either this is the first extrusion path 
+      // or this is an extrusion path that is higher than the last layer
+      if (!this.lastLayer || newZ - lastZ > this.tolerance) {
+        this.createLayerAt(newZ);
       }
     }
-    
-    const layer = this.lastLayer();
-    if (path.travelType === PathType.Extrusion) {
-      layer.z = path.vertices[2]; // ensure the layer's Z position is updated when extruding
-    }
 
-    layer.paths.push(path);
+    this.lastLayer?.paths.push(path);
   }
 
   /**
    * Gets the last layer in the indexes
    * @returns The most recent layer
    */
-  private lastLayer(): Layer {
+  private get lastLayer(): Layer {
     return this.indexes[this.indexes.length - 1];
   }
 
@@ -138,9 +132,10 @@ export class LayersIndexer extends Indexer {
    * Creates a new layer at the specified Z height
    * @param z - Z height for the new layer
    */
-  private createLayer(z: number): void {
-    const height = z - (this.lastLayer()?.z || 0);
-    this.indexes.push(new Layer([], height, z));
+  private createLayerAt(z: number): void {
+    const lastZ = this.lastLayer?.z || 0;
+    const height = z - lastZ;
+    this.indexes.push(new Layer(z, height));
   }
 }
 

--- a/src/indexers.ts
+++ b/src/indexers.ts
@@ -117,7 +117,13 @@ export class LayersIndexer extends Indexer {
         this.createLayer(path.vertices[2]);
       }
     }
-    this.lastLayer().paths.push(path);
+    
+    const layer = this.lastLayer();
+    if (path.travelType === PathType.Extrusion) {
+      layer.z = path.vertices[2]; // ensure the layer's Z position is updated when extruding
+    }
+
+    layer.paths.push(path);
   }
 
   /**

--- a/src/indexers.ts
+++ b/src/indexers.ts
@@ -135,7 +135,7 @@ export class LayersIndexer extends Indexer {
   private createLayer(z: number): void {
     const layerNumber = this.indexes.length;
     const height = z - (this.lastLayer()?.z || 0);
-    this.indexes.push(new Layer(this.indexes.length, [], layerNumber, height, z));
+    this.indexes.push(new Layer([], layerNumber, height, z));
   }
 }
 

--- a/src/indexers.ts
+++ b/src/indexers.ts
@@ -105,12 +105,11 @@ export class LayersIndexer extends Indexer {
     }
 
     // new layers are only created when extruding
-    if (path.travelType === PathType.Extrusion)
-    {
+    if (path.travelType === PathType.Extrusion) {
       const newZ = path.vertices[2];
       const lastZ = this.lastLayer?.z;
 
-      // either this is the first extrusion path 
+      // either this is the first extrusion path
       // or this is an extrusion path that is higher than the last layer
       if (!this.lastLayer || newZ - lastZ > this.tolerance) {
         this.createLayerAt(newZ);

--- a/src/indexers.ts
+++ b/src/indexers.ts
@@ -64,7 +64,7 @@ export class TravelTypeIndexer extends Indexer {
  */
 export class NonPlanarExtrusionError extends NonApplicableIndexer {
   constructor() {
-    super("Non-planar extrusions cannot be indexed by layer");
+    super('Non-planar extrusions cannot be indexed by layer');
   }
 }
 

--- a/src/indexers.ts
+++ b/src/indexers.ts
@@ -62,9 +62,9 @@ export class TravelTypeIndexer extends Indexer {
 /**
  * Error thrown when attempting to index a non-planar path
  */
-export class NonPlanarPathError extends NonApplicableIndexer {
+export class NonPlanarExtrusionError extends NonApplicableIndexer {
   constructor() {
-    super("Non-planar paths can't be indexed by layer");
+    super("Non-planar extrusions cannot be indexed by layer");
   }
 }
 
@@ -101,7 +101,7 @@ export class LayersIndexer extends Indexer {
       path.travelType === PathType.Extrusion &&
       path.vertices.some((_, i, arr) => i > 3 && i % 3 === 2 && Math.abs(arr[i] - arr[i - 3]) > this.tolerance)
     ) {
-      throw new NonPlanarPathError();
+      throw new NonPlanarExtrusionError();
     }
 
     // new layers are only created when extruding

--- a/src/indexers.ts
+++ b/src/indexers.ts
@@ -139,9 +139,8 @@ export class LayersIndexer extends Indexer {
    * @param z - Z height for the new layer
    */
   private createLayer(z: number): void {
-    const layerNumber = this.indexes.length;
     const height = z - (this.lastLayer()?.z || 0);
-    this.indexes.push(new Layer([], layerNumber, height, z));
+    this.indexes.push(new Layer([], height, z));
   }
 }
 

--- a/src/job.ts
+++ b/src/job.ts
@@ -1,7 +1,7 @@
 import { Path } from './path';
 import { State } from './state';
 import { Layer } from './layer';
-import { TravelTypeIndexer, LayersIndexer, ToolIndexer, Indexer, NonApplicableIndexer } from './indexers';
+import { TravelTypeIndexer, LayersIndexer, ToolIndexer, Indexer, NonApplicableIndexer, NonPlanarPathError } from './indexers';
 import { BoundingBox } from './bounding-box';
 
 /**
@@ -159,9 +159,12 @@ export class Job {
           throw e; // If the error is not a NonApplicableIndexer, it will be thrown.
         }
 
-        console.warn('Non-planar path detected; clearing layer index');
-        this._layers = [];
+        if (e instanceof NonPlanarPathError) {
+          console.warn('Non-planar path detected; clearing layer index');
+          this._layers = [];
+        }
 
+        // Remove the indexer that cannot handle this path
         const i = this.indexers.indexOf(indexer);
         this.indexers.splice(i, 1);
       }

--- a/src/job.ts
+++ b/src/job.ts
@@ -7,7 +7,7 @@ import {
   ToolIndexer,
   Indexer,
   NonApplicableIndexer,
-  NonPlanarPathError
+  NonPlanarExtrusionError
 } from './indexers';
 import { BoundingBox } from './bounding-box';
 
@@ -166,7 +166,7 @@ export class Job {
           throw e; // If the error is not a NonApplicableIndexer, it will be thrown.
         }
 
-        if (e instanceof NonPlanarPathError) {
+        if (e instanceof NonPlanarExtrusionError) {
           console.warn('Non-planar path detected; clearing layer index');
           this._layers = [];
         }

--- a/src/job.ts
+++ b/src/job.ts
@@ -135,10 +135,10 @@ export class Job {
   }
 
   /**
-   * Checks if the job contains planar layers
+   * Checks if the job contains planar extrusion layers
    * @returns True if the job contains at least one layer, false otherwise
    */
-  isPlanar(): boolean {
+  get isPlanar(): boolean {
     return this.layers.length > 0;
   }
 

--- a/src/job.ts
+++ b/src/job.ts
@@ -1,7 +1,14 @@
 import { Path } from './path';
 import { State } from './state';
 import { Layer } from './layer';
-import { TravelTypeIndexer, LayersIndexer, ToolIndexer, Indexer, NonApplicableIndexer, NonPlanarPathError } from './indexers';
+import {
+  TravelTypeIndexer,
+  LayersIndexer,
+  ToolIndexer,
+  Indexer,
+  NonApplicableIndexer,
+  NonPlanarPathError
+} from './indexers';
 import { BoundingBox } from './bounding-box';
 
 /**

--- a/src/layer.ts
+++ b/src/layer.ts
@@ -6,29 +6,18 @@ import { Path } from './path';
  * Contains information about the layer number, paths, height, and Z position
  */
 export class Layer {
-  /** Layer number (0-based index) */
-  public layer: number;
-  /** Array of paths in this layer */
-  public paths: Path[];
-  /** Line number in the G-code file where this layer starts */
-  public lineNumber: number;
-  /** Height of this layer */
-  public height: number = 0;
-  /** Z position of this layer */
-  public z: number = 0;
-
   /**
    * Creates a new Layer instance
-   * @param layer - Layer number
    * @param paths - Array of paths in this layer
    * @param lineNumber - Line number in G-code file
    * @param height - Layer height (default: 0)
    * @param z - Z position (default: 0)
    */
-  constructor(paths: Path[], lineNumber: number, height: number = 0, z: number = 0) {
-    this.paths = paths;
-    this.lineNumber = lineNumber;
-    this.height = height;
-    this.z = z;
-  }
+  constructor(
+    public paths: Path[],
+    public lineNumber: number,
+    public height: number = 0,
+    public z: number = 0,
+    public layer: number = 0
+  ) {}
 }

--- a/src/layer.ts
+++ b/src/layer.ts
@@ -6,16 +6,16 @@ import { Path } from './path';
  * Contains information about the layer number, paths, height, and Z position
  */
 export class Layer {
+  /** Array of paths in this layer */
+  paths: Path[] = [];
+  
   /**
    * Creates a new Layer instance
-   * @param paths - Array of paths in this layer
    * @param height - Layer height (default: 0)
    * @param z - Z position (default: 0)
    */
   constructor(
-    public paths: Path[],
+    public z: number,
     public height: number = 0,
-    public z: number = 0,
-    public layer: number = 0
   ) {}
 }

--- a/src/layer.ts
+++ b/src/layer.ts
@@ -25,8 +25,7 @@ export class Layer {
    * @param height - Layer height (default: 0)
    * @param z - Z position (default: 0)
    */
-  constructor(layer: number, paths: Path[], lineNumber: number, height: number = 0, z: number = 0) {
-    this.layer = layer;
+  constructor(paths: Path[], lineNumber: number, height: number = 0, z: number = 0) {
     this.paths = paths;
     this.lineNumber = lineNumber;
     this.height = height;

--- a/src/layer.ts
+++ b/src/layer.ts
@@ -8,7 +8,7 @@ import { Path } from './path';
 export class Layer {
   /** Array of paths in this layer */
   paths: Path[] = [];
-  
+
   /**
    * Creates a new Layer instance
    * @param height - Layer height (default: 0)
@@ -16,6 +16,6 @@ export class Layer {
    */
   constructor(
     public z: number,
-    public height: number = 0,
+    public height: number = 0
   ) {}
 }

--- a/src/layer.ts
+++ b/src/layer.ts
@@ -9,13 +9,11 @@ export class Layer {
   /**
    * Creates a new Layer instance
    * @param paths - Array of paths in this layer
-   * @param lineNumber - Line number in G-code file
    * @param height - Layer height (default: 0)
    * @param z - Z position (default: 0)
    */
   constructor(
     public paths: Path[],
-    public lineNumber: number,
     public height: number = 0,
     public z: number = 0,
     public layer: number = 0

--- a/src/webgl-preview.ts
+++ b/src/webgl-preview.ts
@@ -497,8 +497,10 @@ export class WebGLPreview {
    * @private
    */
   private updateClippingPlanes() {
-    const minZ = this.job.layers[this._startLayer - 1]?.z;
-    const maxZ = this.job.layers[this._endLayer - 1]?.z;
+    const startLayer = this.job.layers[this._startLayer - 1];
+    const endLayer = this.job.layers[this._endLayer - 1];
+    const minZ = startLayer?.z - startLayer?.height;
+    const maxZ = endLayer?.z;
 
     this.updateClippingPlanesForShaderMaterials(minZ, maxZ);
     this.updateLineClipping(minZ, maxZ);


### PR DESCRIPTION
prompted by #304 I was trying to wrap my head around the following problem: CNC jobs resulted in a single layer. Which is odd because a layer is by definition an artifact of 3d printing.

This was caused by the fact that there was always a default layer created initially and every gcode up until the first extrusion was lumped into that first default layer. 

But I think we should reason that the first layer starts when the first extrusion is being made. (of course purge lines etc will still cause issues with this but this is a step in the right direction)

changes:
- gcodes / paths that come before the first extrusion are not indexed into a layer anymore
- the layer class was simplified by removing unused properties (layer number, lineNumber)
- existing tests were updated where the description was out of sync with the accompanying logic
- tests were added for the z prop of a Layer
- the indexer error case was slightly improved and the NonPlanarPathError was renamed to NonPlanarExtrusionError